### PR TITLE
Revamp activity dashboard with interactive filters and details

### DIFF
--- a/activity-detail-placeholder.html
+++ b/activity-detail-placeholder.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="common-styles.css">
+    <link rel="stylesheet" href="styles/activity-dashboard.css">
     <link rel="stylesheet" href="styles/lightbox.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="lightbox.js"></script>
@@ -78,7 +79,6 @@
         </nav>
 
         <article id="activity-article-container" class="container mx-auto px-4 sm:px-6 py-10 bg-white rounded-xl shadow-xl fade-in-section" style="transition-delay: 0.2s;">
-            {/* コンテンツはJavaScript (common-scripts.jsのinitActivityDetailPage) で挿入されます */}
         </article>
         
         <div id="article-not-found" class="hidden container mx-auto px-6 py-20 text-center fade-in-section">

--- a/activity-log.html
+++ b/activity-log.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="common-styles.css">
+    <link rel="stylesheet" href="styles/activity-dashboard.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <script defer src="filters-dynamic.js"></script>
@@ -64,53 +65,56 @@
 
         <section class="py-10 bg-gray-50 fade-in-section" style="transition-delay: 0.2s;">
             <div class="container mx-auto px-6">
-                <div class="bg-white p-6 rounded-xl shadow-lg">
-                    <div class="grid md:grid-cols-4 gap-6 items-end">
+                <div class="bg-white rounded-2xl shadow-xl p-6 md:p-8 space-y-6" id="activity-filter-panel">
+                    <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                         <div>
-                            <label for="activity-category-filter" class="block text-sm font-medium text-gray-700 mb-1">カテゴリ</label>
-                            <select id="activity-category-filter" name="activity-category-filter" class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-green-500 focus:border-green-500 sm:text-sm">
-                                <option value="all">すべてのカテゴリ</option>
-                                <option value="ビーバー隊">ビーバー隊</option>
-                                <option value="カブ隊">カブ隊</option>
-                                <option value="ボーイ隊">ボーイ隊</option>
-                                <option value="ベンチャー隊">ベンチャー隊</option>
-                                <option value="ローバー隊">ローバー隊</option>
-                                <option value="団行事">団行事</option>
-                                <option value="地域奉仕">地域奉仕</option>
-                                <option value="キャンプ">キャンプ</option>
-                                <option value="技能章">技能章</option>
-                            </select>
+                            <p class="text-lg font-semibold text-gray-800">目的の情報へ素早くアクセス</p>
+                            <p class="text-sm text-gray-500">カテゴリやタグ、キーワードを自由に組み合わせて活動を探せます。</p>
                         </div>
+                        <button type="button" id="activity-reset-filters" class="chip chip--ghost self-start md:self-center">条件をリセット</button>
+                    </div>
+
+                    <div class="space-y-6">
                         <div>
-                            <label for="activity-date-filter" class="block text-sm font-medium text-gray-700 mb-1">活動月</label>
-                            <input type="month" id="activity-date-filter" name="activity-date-filter" class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-green-500 focus:border-green-500 sm:text-sm">
+                            <p class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">カテゴリ</p>
+                            <div id="activity-category-chips" class="flex flex-wrap gap-2"></div>
                         </div>
+
                         <div>
-                            <label for="activity-unit-filter" class="block text-sm font-medium text-gray-700 mb-1">隊</label>
-                            <select id="activity-unit-filter" name="activity-unit-filter" class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-green-500 focus:border-green-500 sm:text-sm">
-                                <option value="">すべての隊</option>
-                            </select>
+                            <p class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">隊</p>
+                            <div id="activity-unit-chips" class="flex flex-wrap gap-2"></div>
                         </div>
-                        <div class="md:col-span-2">
-                            <label for="activity-tags-filter" class="block text-sm font-medium text-gray-700 mb-1">タグ</label>
-                            <select id="activity-tags-filter" name="activity-tags-filter" multiple size="4" class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-green-500 focus:border-green-500 sm:text-sm"></select>
+
+                        <div class="space-y-3">
+                            <div class="flex flex-wrap items-center gap-3">
+                                <p class="text-xs font-semibold uppercase tracking-wider text-gray-500">人気タグ</p>
+                                <button type="button" id="activity-tag-mode-toggle" class="chip chip--outline text-xs" aria-pressed="false" aria-label="タグの組み合わせ方法を切り替え">タグ条件: OR</button>
+                            </div>
+                            <div id="activity-tag-bar" class="flex gap-2 overflow-x-auto pb-2 custom-scroll" role="list"></div>
                         </div>
-                        <div class="md:col-span-2">
-                            <label for="activity-search" class="block text-sm font-medium text-gray-700 mb-1">検索</label>
-                            <input type="search" id="activity-search" name="activity-search" placeholder="キーワードで検索" class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-green-500 focus:border-green-500 sm:text-sm">
+
+                        <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-[2fr,1fr,1fr]">
+                            <label class="flex flex-col gap-2">
+                                <span class="text-xs font-semibold uppercase tracking-wider text-gray-500">キーワード検索</span>
+                                <div class="relative flex items-center gap-2 rounded-xl border border-gray-200 bg-gray-50 px-4 py-2 focus-within:border-green-500 focus-within:ring-2 focus-within:ring-green-100 transition">
+                                    <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 105.64 5.64a7.5 7.5 0 0010.61 10.61z"/></svg>
+                                    <input type="search" id="activity-search" name="activity-search" placeholder="タイトルや本文、タグから検索" class="flex-1 bg-transparent focus:outline-none text-sm text-gray-700" autocomplete="off">
+                                </div>
+                            </label>
+                            <label class="flex flex-col gap-2">
+                                <span class="text-xs font-semibold uppercase tracking-wider text-gray-500">活動月</span>
+                                <input type="month" id="activity-date-filter" name="activity-date-filter" class="rounded-xl border border-gray-200 px-4 py-2 text-sm text-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-100 transition" />
+                            </label>
+                            <div class="flex flex-col gap-2">
+                                <span class="text-xs font-semibold uppercase tracking-wider text-gray-500">並び替え</span>
+                                <div id="activity-sort-chips" class="flex flex-wrap gap-2"></div>
+                            </div>
                         </div>
-                        <div class="md:col-span-2">
-                            <button type="button" id="activity-filter-button" class="w-full bg-green-600 hover:bg-green-700 text-white font-semibold py-2.5 px-4 rounded-md shadow-sm transition-all duration-300 ease-in-out flex items-center justify-center active:bg-green-800 active:scale-95">
-                                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
-                                    <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" />
-                                </svg>
-                                <span id="activity-filter-button-text">絞り込む</span>
-                                <svg id="activity-filter-loading-spinner" class="animate-spin -ml-1 mr-3 h-5 w-5 text-white hidden" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                                  </svg>
-                            </button>
-                        </div>
+                    </div>
+
+                    <div id="activity-active-filter-bar" class="hidden flex flex-wrap items-center gap-2 border-t border-gray-100 pt-4">
+                        <span class="text-xs font-semibold uppercase tracking-wider text-gray-500">選択中:</span>
+                        <div id="activity-active-filters" class="flex flex-wrap gap-2"></div>
                     </div>
                 </div>
             </div>
@@ -118,8 +122,24 @@
 
         <section class="py-12 md:py-16 fade-in-section" style="transition-delay: 0.4s;">
             <div class="container mx-auto px-6">
-                <div id="activity-log-container" class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 md:gap-10">
+                <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between mb-8">
+                    <div>
+                        <h2 class="text-3xl font-bold text-gray-800">活動一覧</h2>
+                        <p id="activity-results-count" class="text-sm text-gray-500">読み込み中...</p>
+                    </div>
+                    <div class="flex items-center gap-2 text-xs text-gray-500">
+                        <svg class="h-4 w-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                        <span>タグをクリックすると条件に追加できます。</span>
+                    </div>
                 </div>
+
+                <div id="activity-list-loading" class="flex items-center justify-center py-12">
+                    <span class="loading-spinner" aria-hidden="true"></span>
+                    <span class="ml-3 text-sm text-gray-500">活動を読み込んでいます...</span>
+                </div>
+
+                <div id="activity-log-container" class="grid gap-6 md:grid-cols-2 xl:grid-cols-3"></div>
+
                 <div id="no-activity-results" class="hidden text-center text-gray-600 py-10">
                     <div class="bg-white p-8 rounded-xl shadow-lg max-w-md mx-auto">
                         <svg class="w-20 h-20 text-yellow-400 mx-auto mb-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 10l4 4m0-4l-4 4"></path></svg>
@@ -128,8 +148,12 @@
                         <p class="text-sm mt-4">フィルター条件を変更するか、後日改めてご確認ください。</p>
                     </div>
                 </div>
-                <nav id="activity-pagination-container" aria-label="活動報告ページネーション" class="mt-16 flex justify-center fade-in-section" style="transition-delay: 0.6s;">
-                </nav>
+
+                <div class="flex justify-center mt-10">
+                    <button type="button" id="activity-load-more-button" class="hidden chip chip--solid px-6 py-3 text-base">もっと見る</button>
+                </div>
+                <div id="activity-list-end" class="hidden text-center text-sm text-gray-500 mt-6">すべての活動を表示しました</div>
+                <div id="activity-load-more-sentinel" class="h-px w-full"></div>
             </div>
         </section>
 

--- a/dynamic-activities.v2.js
+++ b/dynamic-activities.v2.js
@@ -1,8 +1,17 @@
-// dynamic-activities.v2.js
+const HISTORY_QUERY_KEY = 'activity-last-query';
+const SCROLL_STORAGE_KEY = 'activity-scroll-position';
+
+const ICON_SET = {
+  camp: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 19h18L12 5 3 19z"></path><path d="M12 5v14"></path></svg>',
+  megaphone: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11v2a2 2 0 002 2h1l3 4v-12l-3 4H5a2 2 0 00-2 2z"></path><path d="M15 9l6-3v12l-6-3"></path></svg>',
+  compass: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"></circle><path d="M15 9l-2 6-6 2 2-6 6-2z"></path></svg>'
+};
+
+const collator = new Intl.Collator('ja');
 
 document.addEventListener('DOMContentLoaded', () => {
   if (document.getElementById('activity-log-container')) {
-    loadDynamicActivityList();
+    new ActivityDashboard();
   }
   if (document.getElementById('activity-article-container')) {
     loadDynamicActivityDetail();
@@ -19,226 +28,1100 @@ function escapeHTML(str) {
     .replace(/'/g, '&#39;');
 }
 
-async function loadDynamicActivityList() {
-  const container = document.getElementById('activity-log-container');
-  if (!container) return;
+function stripHtml(html) {
+  if (!html) return '';
+  const tmp = document.createElement('div');
+  tmp.innerHTML = html;
+  return (tmp.textContent || tmp.innerText || '').trim();
+}
 
-  const pagination = document.getElementById('activity-pagination-container');
-  const noResults = document.getElementById('no-activity-results');
-  const ITEMS_PER_PAGE = 6;
-  let currentPage = 1;
-  let allItems = [];
-
-  const fmtDate = (d) => new Date(d).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' });
-  const getThumb = (item) => {
-    const urls = Array.isArray(item.image_urls) ? item.image_urls : [];
-    return urls.length ? urls[0] : `https://placehold.co/600x360/4A934A/FFFFFF?text=${encodeURIComponent(item.category || '活動')}`;
-  };
-
-  const renderCard = (item) => {
-    const summary = (item.content || '').replace(/<[^>]+>/g, '').substring(0, 120) + '...';
-    const url = `activity-detail-placeholder.html?id=${item.id}`;
-    const dateLabel = item.activity_date ? fmtDate(item.activity_date) : fmtDate(item.created_at);
-    const tags = Array.isArray(item.tags) ? item.tags : [];
-    const tagBadges = tags.slice(0, 6).map(t => `<span class="badge badge--tag mr-2 mb-2">#${escapeHTML(t)}</span>`).join('');
-    const unitBadge = item.unit ? `<span class="badge badge--unit mr-2">${escapeHTML(item.unit)}</span>` : '';
-    const catBadge  = item.category ? `<span class="badge badge--category">${escapeHTML(item.category)}</span>` : '';
-    return `
-      <div class="bg-white rounded-xl shadow-xl overflow-hidden card-hover-effect group" data-activity-id="${item.id}">
-        <div class="relative">
-          <img src="https://placehold.co/600x360/4A934A/FFFFFF?text=${escapeHTML(item.category || '活動')}" alt="${escapeHTML(item.title || '')}" class="w-full h-56 object-cover transition-transform duration-500 group-hover:scale-110" loading="lazy">
-          <div class="absolute inset-0 bg-black/20 group-hover:bg-black/10 transition-colors duration-300"></div>
-        </div>
-        <div class="p-6">
-          <div class="flex items-center justify-between mb-2">
-            <div class="flex items-center gap-2 flex-wrap">${unitBadge}${catBadge}</div>
-            <p class="text-sm text-gray-500">${dateLabel}</p>
-          </div>
-          <h3 class="text-xl font-semibold mb-2">
-            <a href="${url}" class="hover:text-green-700 transition-colors">${escapeHTML(item.title || '')}</a>
-          </h3>
-          <p class="text-gray-700 mb-3 leading-relaxed line-clamp-3">${escapeHTML(summary)}</p>
-          <div class="flex flex-wrap mb-2">${tagBadges}</div>
-          <a href="${url}" class="inline-block text-green-600 hover:text-green-800 font-semibold transition-colors duration-300 group" aria-label="続きを読む">
-            <span class="transition-transform duration-300 inline-block group-hover:translate-x-1">&rarr;</span>
-          </a>
-        </div>
-      </div>`;
-  };
-
-  const renderPagination = (total, page) => {
-    if (!pagination) return;
-    const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
-    if (totalPages <= 1) { pagination.innerHTML = ''; return; }
-    let html = '<ul class="inline-flex items-center -space-x-px shadow-sm rounded-md">';
-    html += `<li><button data-page="${page - 1}" aria-label="前のページへ" class="activity-page-btn pagination-button ${page === 1 ? 'pagination-disabled' : ''}"><span class="sr-only">前へ</span><svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20  20"><path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"></path></svg></button></li>`;
-    for (let i = 1; i <= totalPages; i++) {
-      const isActive = i === page;
-      html += `<li><button data-page="${i}" ${isActive ? 'aria-current="page"' : ''} aria-label="${i}ページ目へ" class="activity-page-btn pagination-button ${isActive ? 'pagination-active' : ''}">${i}</button></li>`;
-    }
-    html += `<li><button data-page="${page + 1}" aria-label="次のページへ" class="activity-page-btn pagination-button ${page === totalPages ? 'pagination-disabled' : ''}"><span class="sr-only">次へ</span><svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg></button></li>`;
-    html += '</ul>';
-    pagination.innerHTML = html;
-    pagination.querySelectorAll('.activity-page-btn').forEach(btn => {
-      btn.addEventListener('click', (e) => {
-        const p = parseInt(e.currentTarget.dataset.page);
-        const totalPages2 = Math.ceil(allItems.length / ITEMS_PER_PAGE);
-        if (p && p !== currentPage && p > 0 && p <= totalPages2) {
-          currentPage = p;
-          draw(allItems);
-          container.scrollIntoView({ behavior: 'smooth' });
-        }
-      });
-    });
-  };
-
-  const draw = (arr) => {
-    container.innerHTML = '';
-    if (!arr || arr.length === 0) {
-      if (noResults) noResults.classList.remove('hidden');
-      if (pagination) pagination.innerHTML = '';
-      return;
-    }
-    if (noResults) noResults.classList.add('hidden');
-    const start = (currentPage - 1) * ITEMS_PER_PAGE;
-    const items = arr.slice(start, start + ITEMS_PER_PAGE);
-    container.innerHTML = items.map(renderCard).join('');
-    try {
-      (function fixThumbs(arr){
-        const cards = container.querySelectorAll('[data-activity-id]');
-        cards.forEach(card=>{
-          const id = Number(card.getAttribute('data-activity-id'));
-          const it = arr.find(x=>Number(x.id)===id);
-          if (!it) return;
-          const urls = Array.isArray(it.image_urls)?it.image_urls:[];
-          if (!urls.length) return;
-          const img = card.querySelector('img');
-          if (img) img.src = urls[0];
-        });
-      })(items);
-    } catch {}
-    renderPagination(arr.length, currentPage);
-  };
-
+function formatDateForDisplay(dateObj) {
+  if (!(dateObj instanceof Date) || Number.isNaN(dateObj.valueOf())) return '';
   try {
-    container.innerHTML = '<p class="text-center">読み込み中...</p>';
-    const qs = window.location.search || '';
-    const resp = await fetch(`/api/activities${qs}`);
-    if (!resp.ok) throw new Error('Network response was not ok');
-    allItems = await resp.json();
-    draw(allItems);
-  } catch (err) {
-    console.error('Failed to fetch activities:', err);
-    container.innerHTML = '<p class="text-center text-red-500">活動の読み込みに失敗しました。</p>';
+    return new Intl.DateTimeFormat('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    }).format(dateObj);
+  } catch {
+    return dateObj.toLocaleDateString();
+  }
+}
+
+function formatMonthLabel(ym) {
+  if (!/^\d{4}-\d{2}$/.test(ym)) return ym;
+  const [y, m] = ym.split('-').map(Number);
+  if (!y || !m) return ym;
+  return `${y}年${m}月`;
+}
+
+function normalizeImageUrl(url) {
+  if (!url) return '';
+  try {
+    const parsed = new URL(url, window.location.origin);
+    if (parsed.hostname.includes('drive.google.com')) {
+      const fileMatch = parsed.pathname.match(/\/file\/d\/([^/]+)/);
+      const id = fileMatch ? fileMatch[1] : parsed.searchParams.get('id');
+      if (id) return `https://drive.google.com/uc?export=view&id=${id}`;
+    }
+    return parsed.href;
+  } catch {
+    return url;
+  }
+}
+
+function normalizeActivity(item) {
+  if (!item || typeof item !== 'object') return null;
+  const normalized = { ...item };
+  const tags = Array.isArray(item.tags) ? item.tags.filter(Boolean) : [];
+  normalized.tags = tags;
+  normalized._tags = tags;
+  normalized._tagsLower = tags.map(tag => String(tag).toLowerCase());
+  const plain = stripHtml(item.content || '');
+  normalized._plain = plain;
+  const summaryLength = 160;
+  normalized._summary = plain.length > summaryLength ? `${plain.slice(0, summaryLength)}…` : plain;
+  const searchParts = [
+    String(item.title || '').toLowerCase(),
+    plain.toLowerCase(),
+    normalized._tagsLower.join(' '),
+    String(item.category || '').toLowerCase(),
+    String(item.unit || '').toLowerCase()
+  ];
+  normalized._searchBlob = searchParts.join(' ');
+  const dateStr = item.activity_date || item.created_at;
+  const dateObj = dateStr ? new Date(dateStr) : null;
+  normalized._dateObj = (dateObj && !Number.isNaN(dateObj.valueOf())) ? dateObj : null;
+  normalized._displayDate = normalized._dateObj ? formatDateForDisplay(normalized._dateObj) : '';
+  normalized._isoDate = normalized._dateObj ? normalized._dateObj.toISOString() : '';
+  normalized._month = normalized._dateObj ? `${normalized._dateObj.getFullYear()}-${String(normalized._dateObj.getMonth() + 1).padStart(2, '0')}` : '';
+  normalized._isImportant = Boolean(item.is_important) || normalized._tagsLower.some(tag => tag.includes('重要') || tag.includes('urgent'));
+  const now = new Date();
+  normalized._isRecent = normalized._dateObj ? ((now - normalized._dateObj) / (1000 * 60 * 60 * 24)) <= 21 : false;
+  normalized.kind = item.kind || item.type || '';
+  return normalized;
+}
+
+function resolveAccentTheme(item) {
+  const base = {
+    color: '#16a34a',
+    icon: 'camp',
+    typeLabel: '活動報告',
+    iconBg: 'rgba(16, 185, 129, 0.16)',
+    badgeBg: 'rgba(187, 247, 208, 0.7)',
+    badgeColor: '#14532d',
+    tagBg: 'rgba(187, 247, 208, 0.65)',
+    tagColor: '#166534',
+    tagActiveBg: 'rgba(16, 185, 129, 0.25)',
+    tagActiveColor: '#14532d',
+    typeColor: '#0f172a'
+  };
+  const category = String(item?.category || '').toLowerCase();
+  const type = String(item?.kind || '').toLowerCase();
+  if (type.includes('news') || /お知らせ|告知|重要|募集/.test(category)) {
+    return {
+      ...base,
+      color: '#0284c7',
+      icon: 'megaphone',
+      typeLabel: 'お知らせ',
+      iconBg: 'rgba(2, 132, 199, 0.18)',
+      badgeBg: 'rgba(191, 219, 254, 0.7)',
+      badgeColor: '#1e3a8a',
+      tagBg: 'rgba(191, 219, 254, 0.68)',
+      tagColor: '#1d4ed8',
+      tagActiveBg: 'rgba(30, 64, 175, 0.22)',
+      tagActiveColor: '#1e3a8a',
+      typeColor: '#1d4ed8'
+    };
+  }
+  if (/キャンプ|野営|ハイキング|登山|自然/.test(category)) {
+    return {
+      ...base,
+      color: '#ea580c',
+      icon: 'camp',
+      iconBg: 'rgba(250, 146, 73, 0.2)',
+      badgeBg: 'rgba(254, 215, 170, 0.7)',
+      badgeColor: '#7c2d12',
+      tagBg: 'rgba(254, 215, 170, 0.7)',
+      tagColor: '#9a3412',
+      tagActiveBg: 'rgba(234, 88, 12, 0.22)',
+      tagActiveColor: '#7c2d12',
+      typeColor: '#ea580c'
+    };
+  }
+  if (/技能|スキル|章|訓練|チャレンジ/.test(category)) {
+    return {
+      ...base,
+      color: '#7c3aed',
+      icon: 'compass',
+      iconBg: 'rgba(167, 139, 250, 0.22)',
+      badgeBg: 'rgba(221, 214, 254, 0.75)',
+      badgeColor: '#5b21b6',
+      tagBg: 'rgba(221, 214, 254, 0.7)',
+      tagColor: '#5b21b6',
+      tagActiveBg: 'rgba(109, 40, 217, 0.22)',
+      tagActiveColor: '#4c1d95',
+      typeColor: '#7c3aed'
+    };
+  }
+  if (/奉仕|ボランティア|地域|清掃|sdgs/.test(category)) {
+    return {
+      ...base,
+      color: '#0ea5e9',
+      icon: 'compass',
+      iconBg: 'rgba(125, 211, 252, 0.22)',
+      badgeBg: 'rgba(186, 230, 253, 0.75)',
+      badgeColor: '#0c4a6e',
+      tagBg: 'rgba(186, 230, 253, 0.7)',
+      tagColor: '#075985',
+      tagActiveBg: 'rgba(14, 165, 233, 0.22)',
+      tagActiveColor: '#075985',
+      typeColor: '#0ea5e9'
+    };
+  }
+  if (/団行事|式典|交流|イベント|発表/.test(category)) {
+    return {
+      ...base,
+      color: '#ec4899',
+      icon: 'camp',
+      iconBg: 'rgba(244, 114, 182, 0.22)',
+      badgeBg: 'rgba(251, 207, 232, 0.75)',
+      badgeColor: '#9d174d',
+      tagBg: 'rgba(251, 207, 232, 0.7)',
+      tagColor: '#9d174d',
+      tagActiveBg: 'rgba(236, 72, 153, 0.22)',
+      tagActiveColor: '#9d174d',
+      typeColor: '#ec4899'
+    };
+  }
+  return base;
+}
+
+class ActivityDashboard {
+  constructor() {
+    this.container = document.getElementById('activity-log-container');
+    if (!this.container) return;
+
+    this.loadingIndicator = document.getElementById('activity-list-loading');
+    this.noResults = document.getElementById('no-activity-results');
+    this.resultsCount = document.getElementById('activity-results-count');
+    this.loadMoreButton = document.getElementById('activity-load-more-button');
+    this.listEnd = document.getElementById('activity-list-end');
+    this.sentinel = document.getElementById('activity-load-more-sentinel');
+    this.tagBar = document.getElementById('activity-tag-bar');
+    this.categoryChips = document.getElementById('activity-category-chips');
+    this.unitChips = document.getElementById('activity-unit-chips');
+    this.sortChips = document.getElementById('activity-sort-chips');
+    this.searchInput = document.getElementById('activity-search');
+    this.monthInput = document.getElementById('activity-date-filter');
+    this.tagModeToggle = document.getElementById('activity-tag-mode-toggle');
+    this.resetButton = document.getElementById('activity-reset-filters');
+    this.activeFilterBar = document.getElementById('activity-active-filter-bar');
+    this.activeFilters = document.getElementById('activity-active-filters');
+
+    this.defaultState = {
+      category: '',
+      unit: '',
+      tags: [],
+      tagMode: 'or',
+      ym: '',
+      search: '',
+      sort: 'newest',
+      page: 1
+    };
+
+    this.state = { ...this.defaultState, ...this.parseStateFromURL() };
+
+    this.allItems = [];
+    this.filteredItems = [];
+    this.visibleCount = 0;
+    this.batchSize = 9;
+
+    this.categoryChipMap = new Map();
+    this.unitChipMap = new Map();
+    this.tagChipMap = new Map();
+    this.sortChipMap = new Map();
+
+    this.intersectionObserver = null;
+    this.pendingScroll = null;
+    this.searchDebounceTimer = null;
+
+    this.container.setAttribute('aria-live', 'polite');
+    this.container.setAttribute('aria-busy', 'true');
+
+    this.setupEventListeners();
+    this.setupPopState();
+    this.setupScrollStorage();
+    this.loadData();
   }
 
-  // フィルタ（カテゴリ + 月）
-  const btn = document.getElementById('activity-filter-button');
-  const catSel = document.getElementById('activity-category-filter');
-  const monthInp = document.getElementById('activity-date-filter');
-  const btnText = document.getElementById('activity-filter-button-text');
-  const spinner = document.getElementById('activity-filter-loading-spinner');
-  if (btn && catSel && monthInp) {
-    btn.addEventListener('click', () => {
-      try {
-        spinner?.classList?.remove('hidden');
-        if (btnText) btnText.textContent = '絞り込み中...';
-        const cat = (catSel.value || 'all').trim();
-        const ym = (monthInp.value || '').trim(); // YYYY-MM
-        currentPage = 1;
-        const filtered = allItems.filter(n => {
-          let ok = true;
-          if (cat && cat !== 'all') ok = ok && String(n.category || '') === cat;
-          if (ym) {
-            const base = n.activity_date || n.created_at;
-            const d = new Date(base);
-            const y = d.getFullYear();
-            const m = String(d.getMonth() + 1).padStart(2, '0');
-            ok = ok && `${y}-${m}` === ym;
-          }
-          return ok;
-        });
-        draw(filtered);
-      } finally {
-        spinner?.classList?.add('hidden');
-        if (btnText) btnText.textContent = '絞り込み';
+  parseStateFromURL() {
+    const params = new URLSearchParams(window.location.search);
+    const state = {};
+    const cat = params.get('category') || params.get('type');
+    if (cat) state.category = cat;
+    const unit = params.get('unit');
+    if (unit) state.unit = unit;
+    const tagsParam = params.get('tags') || params.get('tag');
+    if (tagsParam) state.tags = tagsParam.split(/[\s,]+/).filter(Boolean);
+    const tagMode = params.get('tagMode');
+    if (tagMode === 'and' || tagMode === 'or') state.tagMode = tagMode;
+    const ym = params.get('ym') || params.get('month');
+    if (ym && /^\d{4}-\d{2}$/.test(ym)) state.ym = ym;
+    const search = params.get('search') || params.get('q');
+    if (search) state.search = search;
+    const sort = params.get('sort');
+    if (['newest', 'oldest', 'title'].includes(sort)) state.sort = sort;
+    const page = parseInt(params.get('page'), 10);
+    if (!Number.isNaN(page) && page > 0) state.page = page;
+    return state;
+  }
+
+  setupEventListeners() {
+    if (this.categoryChips) {
+      this.categoryChips.addEventListener('click', (event) => {
+        const chip = event.target.closest('[data-value]');
+        if (!chip) return;
+        const value = chip.dataset.value || '';
+        this.toggleCategory(value);
+      });
+    }
+
+    if (this.unitChips) {
+      this.unitChips.addEventListener('click', (event) => {
+        const chip = event.target.closest('[data-value]');
+        if (!chip) return;
+        const value = chip.dataset.value || '';
+        this.toggleUnit(value);
+      });
+    }
+
+    if (this.sortChips) {
+      this.sortChips.addEventListener('click', (event) => {
+        const chip = event.target.closest('[data-value]');
+        if (!chip) return;
+        const value = chip.dataset.value || 'newest';
+        this.setSort(value);
+      });
+    }
+
+    if (this.tagBar) {
+      this.tagBar.addEventListener('click', (event) => {
+        const chip = event.target.closest('[data-value]');
+        if (!chip) return;
+        const tag = chip.dataset.value || '';
+        this.toggleTag(tag);
+      });
+    }
+
+    if (this.searchInput) {
+      this.searchInput.value = this.state.search;
+      this.searchInput.addEventListener('input', () => {
+        const value = this.searchInput.value;
+        if (this.searchDebounceTimer) clearTimeout(this.searchDebounceTimer);
+        this.searchDebounceTimer = setTimeout(() => {
+          this.state.search = value.trim();
+          this.state.page = 1;
+          this.applyFilters({ replaceHistory: true });
+        }, 260);
+      });
+    }
+
+    if (this.monthInput) {
+      this.monthInput.value = this.state.ym;
+      this.monthInput.addEventListener('change', () => {
+        const value = this.monthInput.value;
+        this.state.ym = value;
+        this.state.page = 1;
+        this.applyFilters({ replaceHistory: true });
+      });
+    }
+
+    if (this.tagModeToggle) {
+      this.tagModeToggle.addEventListener('click', () => {
+        this.state.tagMode = this.state.tagMode === 'and' ? 'or' : 'and';
+        this.state.page = 1;
+        this.syncTagModeToggle();
+        this.applyFilters({ replaceHistory: true });
+      });
+    }
+
+    if (this.resetButton) {
+      this.resetButton.addEventListener('click', () => {
+        this.resetFilters();
+      });
+    }
+
+    if (this.activeFilters) {
+      this.activeFilters.addEventListener('click', (event) => {
+        const btn = event.target.closest('[data-remove]');
+        if (!btn) return;
+        const key = btn.dataset.remove;
+        const value = btn.dataset.value || '';
+        this.removeFilter(key, value);
+      });
+    }
+
+    if (this.loadMoreButton) {
+      this.loadMoreButton.addEventListener('click', () => {
+        this.loadNextBatch();
+      });
+    }
+
+    this.container.addEventListener('click', (event) => {
+      const tagBtn = event.target.closest('[data-filter-tag]');
+      if (tagBtn) {
+        event.preventDefault();
+        this.toggleTag(tagBtn.dataset.filterTag || '');
+        return;
+      }
+      const unitBtn = event.target.closest('[data-filter-unit]');
+      if (unitBtn) {
+        event.preventDefault();
+        this.toggleUnit(unitBtn.dataset.filterUnit || '');
+        return;
+      }
+      const categoryBtn = event.target.closest('[data-filter-category]');
+      if (categoryBtn) {
+        event.preventDefault();
+        this.toggleCategory(categoryBtn.dataset.filterCategory || '');
+        return;
+      }
+      const detailLink = event.target.closest('a[href*="activity-detail-placeholder.html"]');
+      if (detailLink) {
+        this.storeScrollPosition();
+        try {
+          sessionStorage.setItem(HISTORY_QUERY_KEY, window.location.search || '');
+        } catch {}
       }
     });
+
+    this.container.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      const target = event.target.closest('[role="button"]');
+      if (target) {
+        event.preventDefault();
+        target.click();
+      }
+    });
+  }
+
+  setupPopState() {
+    window.addEventListener('popstate', () => {
+      this.state = { ...this.defaultState, ...this.parseStateFromURL() };
+      this.state.page = Math.max(1, this.state.page || 1);
+      this.syncInputsFromState();
+      this.applyFilters({ updateHistory: false, reset: true });
+    });
+  }
+
+  setupScrollStorage() {
+    try {
+      window.history.scrollRestoration = 'manual';
+    } catch {}
+    try {
+      const stored = sessionStorage.getItem(SCROLL_STORAGE_KEY);
+      if (stored) {
+        const value = parseInt(stored, 10);
+        if (!Number.isNaN(value)) this.pendingScroll = value;
+      }
+    } catch {}
+    const save = () => this.storeScrollPosition();
+    window.addEventListener('beforeunload', save);
+    window.addEventListener('pagehide', save);
+  }
+
+  async loadData() {
+    try {
+      this.showLoading(true);
+      const resp = await fetch('/api/activities?limit=500');
+      if (!resp.ok) throw new Error('Network response was not ok');
+      const data = await resp.json();
+      this.allItems = Array.isArray(data) ? data.map(normalizeActivity).filter(Boolean) : [];
+      this.buildFilterOptions();
+      this.syncInputsFromState();
+      this.applyFilters({ updateHistory: false, reset: true });
+      this.updateURL({ push: false, replace: true });
+    } catch (error) {
+      console.error('Failed to fetch activities:', error);
+      if (this.resultsCount) this.resultsCount.textContent = '活動の読み込みに失敗しました。';
+      this.container.innerHTML = '<p class="text-center text-red-500">活動の読み込みに失敗しました。</p>';
+    } finally {
+      this.showLoading(false);
+      this.container.setAttribute('aria-busy', 'false');
+    }
+  }
+
+  buildFilterOptions() {
+    const categories = this.collectUnique('category');
+    const units = this.collectUnique('unit');
+    const tagCounts = this.collectTagCounts();
+
+    if (this.categoryChips) {
+      this.categoryChips.innerHTML = '';
+      this.categoryChipMap.clear();
+      const fragment = document.createDocumentFragment();
+      const allChip = this.createChip('すべて', '', this.state.category === '');
+      allChip.dataset.value = '';
+      fragment.appendChild(allChip);
+      this.categoryChipMap.set('', allChip);
+      categories.forEach((category) => {
+        const chip = this.createChip(category, category, this.state.category === category);
+        chip.dataset.value = category;
+        fragment.appendChild(chip);
+        this.categoryChipMap.set(category, chip);
+      });
+      this.categoryChips.appendChild(fragment);
+    }
+
+    if (this.unitChips) {
+      this.unitChips.innerHTML = '';
+      this.unitChipMap.clear();
+      const fragment = document.createDocumentFragment();
+      const allChip = this.createChip('すべて', '', this.state.unit === '');
+      allChip.dataset.value = '';
+      fragment.appendChild(allChip);
+      this.unitChipMap.set('', allChip);
+      units.forEach((unit) => {
+        const chip = this.createChip(unit, unit, this.state.unit === unit);
+        chip.dataset.value = unit;
+        fragment.appendChild(chip);
+        this.unitChipMap.set(unit, chip);
+      });
+      this.unitChips.appendChild(fragment);
+    }
+
+    if (this.sortChips) {
+      this.sortChips.innerHTML = '';
+      this.sortChipMap.clear();
+      const options = [
+        { value: 'newest', label: '新着順' },
+        { value: 'oldest', label: '古い順' },
+        { value: 'title', label: 'タイトル順' }
+      ];
+      const fragment = document.createDocumentFragment();
+      options.forEach((opt) => {
+        const chip = this.createChip(opt.label, opt.value, this.state.sort === opt.value, ['chip--outline']);
+        chip.dataset.value = opt.value;
+        fragment.appendChild(chip);
+        this.sortChipMap.set(opt.value, chip);
+      });
+      this.sortChips.appendChild(fragment);
+    }
+
+    if (this.tagBar) {
+      this.tagBar.innerHTML = '';
+      this.tagChipMap.clear();
+      const fragment = document.createDocumentFragment();
+      tagCounts.slice(0, 24).forEach(([tag, count]) => {
+        const chip = this.createChip(`#${tag}`, tag, this.state.tags.includes(tag), ['chip--outline']);
+        chip.dataset.value = tag;
+        chip.innerHTML = `<span>#${escapeHTML(tag)}</span><span class="chip__count">${count}</span>`;
+        chip.setAttribute('aria-pressed', this.state.tags.includes(tag) ? 'true' : 'false');
+        fragment.appendChild(chip);
+        this.tagChipMap.set(tag, chip);
+      });
+      if (!fragment.children.length) {
+        const empty = document.createElement('p');
+        empty.className = 'text-sm text-gray-500';
+        empty.textContent = 'タグ情報はまだありません。';
+        this.tagBar.appendChild(empty);
+      } else {
+        this.tagBar.appendChild(fragment);
+      }
+    }
+
+    this.syncTagModeToggle();
+  }
+
+  collectUnique(key) {
+    const set = new Set();
+    this.allItems.forEach((item) => {
+      const value = (item && item[key]) ? String(item[key]).trim() : '';
+      if (value) set.add(value);
+    });
+    return Array.from(set).sort((a, b) => collator.compare(a, b));
+  }
+
+  collectTagCounts() {
+    const map = new Map();
+    this.allItems.forEach((item) => {
+      const tags = Array.isArray(item?._tags) ? item._tags : [];
+      tags.forEach((tag) => {
+        const key = String(tag).trim();
+        if (!key) return;
+        map.set(key, (map.get(key) || 0) + 1);
+      });
+    });
+    return Array.from(map.entries()).sort((a, b) => {
+      if (b[1] !== a[1]) return b[1] - a[1];
+      return collator.compare(a[0], b[0]);
+    });
+  }
+
+  createChip(label, value, isActive, extraClasses = []) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = ['chip', ...extraClasses].join(' ');
+    if (isActive) button.classList.add('chip--active');
+    button.dataset.value = value;
+    button.textContent = label;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    return button;
+  }
+
+  toggleChipActive(chip, isActive) {
+    if (!chip) return;
+    chip.classList.toggle('chip--active', Boolean(isActive));
+    chip.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  }
+
+  syncTagModeToggle() {
+    if (!this.tagModeToggle) return;
+    const isAnd = this.state.tagMode === 'and';
+    this.tagModeToggle.classList.toggle('chip--active', isAnd);
+    this.tagModeToggle.setAttribute('aria-pressed', isAnd ? 'true' : 'false');
+    this.tagModeToggle.textContent = `タグ条件: ${isAnd ? 'AND (全て含む)' : 'OR (いずれか含む)'}`;
+  }
+
+  syncInputsFromState() {
+    this.categoryChipMap.forEach((chip, value) => this.toggleChipActive(chip, this.state.category === value));
+    this.unitChipMap.forEach((chip, value) => this.toggleChipActive(chip, this.state.unit === value));
+    this.sortChipMap.forEach((chip, value) => this.toggleChipActive(chip, this.state.sort === value));
+    this.tagChipMap.forEach((chip, value) => {
+      const active = this.state.tags.includes(value);
+      this.toggleChipActive(chip, active);
+      chip.classList.toggle('is-muted', this.state.tags.length > 0 && !active);
+    });
+    if (this.searchInput && this.searchInput.value !== this.state.search) {
+      this.searchInput.value = this.state.search;
+    }
+    if (this.monthInput && this.monthInput.value !== this.state.ym) {
+      this.monthInput.value = this.state.ym;
+    }
+    this.syncTagModeToggle();
+  }
+
+  applyFilters({ updateHistory = true, replaceHistory = false, reset = true } = {}) {
+    this.filteredItems = this.filterItems();
+    if (!this.filteredItems.length) {
+      this.state.page = 1;
+    }
+    const maxPage = Math.max(1, Math.ceil(Math.max(this.filteredItems.length, 1) / this.batchSize));
+    if (this.state.page > maxPage) this.state.page = maxPage;
+    if (reset) {
+      this.container.innerHTML = '';
+      this.visibleCount = 0;
+    }
+    this.render({ reset });
+    this.updateResultsCount();
+    this.updateActiveFilters();
+    if (updateHistory) this.updateURL({ push: !replaceHistory, replace: replaceHistory });
+  }
+
+  filterItems() {
+    const { category, unit, tags, tagMode, ym, search, sort } = this.state;
+    const normalizedTags = Array.isArray(tags) ? tags.map(tag => String(tag)) : [];
+    const searchWords = search ? search.trim().toLowerCase().split(/\s+/).filter(Boolean) : [];
+    const isAnd = tagMode === 'and';
+    return this.allItems.filter((item) => {
+      if (category && String(item.category || '') !== category) return false;
+      if (unit && String(item.unit || '') !== unit) return false;
+      if (ym && item._month !== ym) return false;
+      if (normalizedTags.length) {
+        const lowerTags = item._tagsLower || [];
+        if (isAnd) {
+          const every = normalizedTags.every(tag => lowerTags.includes(tag.toLowerCase()));
+          if (!every) return false;
+        } else {
+          const some = normalizedTags.some(tag => lowerTags.includes(tag.toLowerCase()));
+          if (!some) return false;
+        }
+      }
+      if (searchWords.length) {
+        const blob = item._searchBlob || '';
+        const ok = searchWords.every(word => blob.includes(word));
+        if (!ok) return false;
+      }
+      return true;
+    }).sort((a, b) => {
+      if (sort === 'oldest') {
+        return (a._dateObj ? a._dateObj.getTime() : 0) - (b._dateObj ? b._dateObj.getTime() : 0);
+      }
+      if (sort === 'title') {
+        return collator.compare(a.title || '', b.title || '');
+      }
+      return (b._dateObj ? b._dateObj.getTime() : 0) - (a._dateObj ? a._dateObj.getTime() : 0);
+    });
+  }
+
+  render({ reset = false } = {}) {
+    this.showLoading(false);
+    if (!this.filteredItems.length) {
+      if (reset) this.container.innerHTML = '';
+      this.noResults?.classList?.remove('hidden');
+      this.loadMoreButton?.classList?.add('hidden');
+      this.listEnd?.classList?.add('hidden');
+      if (this.sentinel) this.sentinel.classList.add('hidden');
+      return;
+    }
+    this.noResults?.classList?.add('hidden');
+
+    const totalShouldDisplay = Math.min(this.filteredItems.length, this.state.page * this.batchSize);
+    const fragment = document.createDocumentFragment();
+    for (let i = this.visibleCount; i < totalShouldDisplay; i += 1) {
+      const card = this.createCard(this.filteredItems[i]);
+      fragment.appendChild(card);
+    }
+    if (fragment.children.length) {
+      this.container.appendChild(fragment);
+    }
+    this.visibleCount = totalShouldDisplay;
+
+    const hasMore = this.visibleCount < this.filteredItems.length;
+    if (hasMore) {
+      this.loadMoreButton?.classList?.remove('hidden');
+      this.listEnd?.classList?.add('hidden');
+      if (this.sentinel) this.sentinel.classList.remove('hidden');
+    } else {
+      this.loadMoreButton?.classList?.add('hidden');
+      this.listEnd?.classList?.remove('hidden');
+      if (this.sentinel) this.sentinel.classList.add('hidden');
+    }
+
+    this.setupIntersectionObserver();
+    this.restoreScrollIfNeeded();
+  }
+
+  createCard(item) {
+    const accent = resolveAccentTheme(item);
+    const card = document.createElement('article');
+    card.className = 'activity-card';
+    card.dataset.activityId = String(item.id || '');
+    card.style.setProperty('--accent-color', accent.color);
+    card.style.setProperty('--icon-color', accent.color);
+    card.style.setProperty('--icon-bg', accent.iconBg);
+    card.style.setProperty('--type-color', accent.typeColor || accent.color);
+    card.style.setProperty('--tag-bg', accent.tagBg);
+    card.style.setProperty('--tag-color', accent.tagColor);
+    card.style.setProperty('--tag-active-bg', accent.tagActiveBg);
+    card.style.setProperty('--tag-active-color', accent.tagActiveColor);
+    card.style.setProperty('--badge-bg', accent.badgeBg);
+    card.style.setProperty('--badge-color', accent.badgeColor);
+
+    const statusBadges = [];
+    if (item._isImportant) {
+      statusBadges.push('<span class="activity-card__status" aria-label="重要なお知らせ">重要</span>');
+    }
+    if (item._isRecent && !item._isImportant) {
+      statusBadges.push('<span class="activity-card__status" style="color:#1d4ed8;background:rgba(59,130,246,0.16)">NEW</span>');
+    }
+
+    const unitBadge = item.unit ? `<span class="activity-card__badge" role="button" tabindex="0" data-filter-unit="${escapeHTML(item.unit)}" style="--badge-bg:rgba(191,219,254,0.7);--badge-color:#1d4ed8;">${escapeHTML(item.unit)}</span>` : '';
+    const categoryBadge = item.category ? `<span class="activity-card__badge" role="button" tabindex="0" data-filter-category="${escapeHTML(item.category)}">${escapeHTML(item.category)}</span>` : '';
+
+    const tags = Array.isArray(item._tags) ? item._tags.slice(0, 8) : [];
+    const tagsHtml = tags.map((tag) => {
+      const label = String(tag);
+      const active = this.state.tags.includes(label);
+      return `<button type="button" class="activity-card__tag${active ? ' is-active' : ''}" data-filter-tag="${escapeHTML(label)}" aria-pressed="${active ? 'true' : 'false'}">#${escapeHTML(label)}</button>`;
+    }).join('');
+
+    const url = `activity-detail-placeholder.html?id=${encodeURIComponent(item.id)}`;
+
+    card.innerHTML = `
+      <div class="activity-card__accent"></div>
+      <div class="activity-card__type">
+        <span class="activity-card__icon" aria-hidden="true">${ICON_SET[accent.icon] || ICON_SET.camp}</span>
+        <span class="activity-card__type-label">${escapeHTML(accent.typeLabel)}</span>
+        ${statusBadges.join('')}
+      </div>
+      <h3 class="activity-card__title">
+        <a href="${url}">${escapeHTML(item.title || '')}</a>
+      </h3>
+      <p class="activity-card__summary">${escapeHTML(item._summary || '')}</p>
+      <div class="activity-card__meta">
+        <div class="activity-card__badges">${unitBadge}${categoryBadge}</div>
+        <time datetime="${escapeHTML(item._isoDate || '')}">${escapeHTML(item._displayDate || '')}</time>
+      </div>
+      ${tagsHtml ? `<div class="activity-card__tags">${tagsHtml}</div>` : ''}
+      <a class="activity-card__link" href="${url}" aria-label="${escapeHTML(item.title || '')}の詳細を読む">続きを読む<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"></path><path d="M13 6l6 6-6 6"></path></svg></a>
+    `;
+    return card;
+  }
+
+  updateResultsCount() {
+    if (!this.resultsCount) return;
+    if (!this.filteredItems.length) {
+      this.resultsCount.textContent = '該当する活動はありません。条件を変更してみてください。';
+      return;
+    }
+    const total = this.filteredItems.length;
+    const visible = this.visibleCount;
+    const tagModeLabel = this.state.tags.length > 1 ? `（タグ条件: ${this.state.tagMode.toUpperCase()}）` : '';
+    this.resultsCount.textContent = `${total}件中 ${visible}件を表示中${tagModeLabel}`;
+  }
+
+  updateActiveFilters() {
+    if (!this.activeFilters || !this.activeFilterBar) return;
+    const chips = [];
+    if (this.state.category) chips.push(this.createActiveFilterChip('カテゴリ', this.state.category, 'category'));
+    if (this.state.unit) chips.push(this.createActiveFilterChip('隊', this.state.unit, 'unit'));
+    if (this.state.ym) chips.push(this.createActiveFilterChip('活動月', formatMonthLabel(this.state.ym), 'ym'));
+    if (this.state.search) chips.push(this.createActiveFilterChip('キーワード', this.state.search, 'search'));
+    this.state.tags.forEach((tag) => chips.push(this.createActiveFilterChip(`#${tag}`, tag, 'tag')));
+    if (this.state.sort !== 'newest') chips.push(this.createActiveFilterChip('並び順', this.getSortLabel(this.state.sort), 'sort'));
+    if (this.state.tagMode === 'and' && this.state.tags.length > 1) chips.push(this.createActiveFilterChip('タグ条件 AND', 'and', 'tagMode'));
+
+    this.activeFilters.innerHTML = '';
+    chips.forEach((chip) => this.activeFilters.appendChild(chip));
+    if (chips.length) {
+      this.activeFilterBar.classList.remove('hidden');
+    } else {
+      this.activeFilterBar.classList.add('hidden');
+    }
+  }
+
+  createActiveFilterChip(label, value, key) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'chip chip--outline';
+    button.dataset.remove = key;
+    if (value) button.dataset.value = value;
+    button.innerHTML = `<span>${escapeHTML(label)}${value && key !== 'tagMode' && !label.startsWith('#') ? `: ${escapeHTML(value)}` : ''}</span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 6l12 12M6 18L18 6"></path></svg>`;
+    button.setAttribute('aria-label', `${label}を解除`);
+    return button;
+  }
+
+  getSortLabel(value) {
+    if (value === 'oldest') return '古い順';
+    if (value === 'title') return 'タイトル順';
+    return '新着順';
+  }
+
+  updateURL({ push = true, replace = false } = {}) {
+    const params = new URLSearchParams();
+    if (this.state.category) params.set('category', this.state.category);
+    if (this.state.unit) params.set('unit', this.state.unit);
+    if (this.state.tags.length) params.set('tags', this.state.tags.join(','));
+    if (this.state.tagMode === 'and') params.set('tagMode', 'and');
+    if (this.state.ym) params.set('ym', this.state.ym);
+    if (this.state.search) params.set('search', this.state.search);
+    if (this.state.sort !== 'newest') params.set('sort', this.state.sort);
+    if (this.state.page > 1) params.set('page', String(this.state.page));
+    const query = params.toString();
+    const newUrl = `${window.location.pathname}${query ? `?${query}` : ''}`;
+    try {
+      if (replace) {
+        window.history.replaceState({}, '', newUrl);
+      } else if (push) {
+        window.history.pushState({}, '', newUrl);
+      } else {
+        window.history.replaceState({}, '', newUrl);
+      }
+      sessionStorage.setItem(HISTORY_QUERY_KEY, query ? `?${query}` : '');
+    } catch (error) {
+      console.warn('Failed to update history state', error);
+    }
+  }
+
+  toggleCategory(value) {
+    this.state.category = this.state.category === value ? '' : value;
+    this.state.page = 1;
+    this.syncInputsFromState();
+    this.applyFilters({ replaceHistory: true });
+  }
+
+  toggleUnit(value) {
+    this.state.unit = this.state.unit === value ? '' : value;
+    this.state.page = 1;
+    this.syncInputsFromState();
+    this.applyFilters({ replaceHistory: true });
+  }
+
+  setSort(value) {
+    if (!['newest', 'oldest', 'title'].includes(value)) value = 'newest';
+    this.state.sort = value;
+    this.state.page = 1;
+    this.syncInputsFromState();
+    this.applyFilters({ replaceHistory: true });
+  }
+
+  toggleTag(tag) {
+    const value = String(tag).trim();
+    if (!value) return;
+    const has = this.state.tags.includes(value);
+    this.state.tags = has ? this.state.tags.filter(t => t !== value) : [...this.state.tags, value];
+    this.state.page = 1;
+    this.syncInputsFromState();
+    this.applyFilters({ replaceHistory: true });
+  }
+
+  removeFilter(key, value) {
+    switch (key) {
+      case 'category':
+        this.state.category = '';
+        break;
+      case 'unit':
+        this.state.unit = '';
+        break;
+      case 'ym':
+        this.state.ym = '';
+        if (this.monthInput) this.monthInput.value = '';
+        break;
+      case 'search':
+        this.state.search = '';
+        if (this.searchInput) this.searchInput.value = '';
+        break;
+      case 'tag':
+        this.state.tags = this.state.tags.filter(tag => tag !== value);
+        break;
+      case 'sort':
+        this.state.sort = 'newest';
+        break;
+      case 'tagMode':
+        this.state.tagMode = 'or';
+        break;
+      default:
+        break;
+    }
+    this.state.page = 1;
+    this.syncInputsFromState();
+    this.applyFilters({ replaceHistory: true });
+  }
+
+  resetFilters() {
+    this.state = { ...this.defaultState };
+    if (this.searchInput) this.searchInput.value = '';
+    if (this.monthInput) this.monthInput.value = '';
+    this.syncInputsFromState();
+    this.applyFilters({ replaceHistory: true });
+  }
+
+  loadNextBatch() {
+    if (this.visibleCount >= this.filteredItems.length) return;
+    this.state.page += 1;
+    this.render({ reset: false });
+    this.updateResultsCount();
+    this.updateURL({ push: false, replace: true });
+  }
+
+  setupIntersectionObserver() {
+    if (!this.sentinel || !('IntersectionObserver' in window)) return;
+    if (!this.intersectionObserver) {
+      this.intersectionObserver = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            this.loadNextBatch();
+          }
+        });
+      }, { rootMargin: '120px' });
+    }
+    this.intersectionObserver.disconnect();
+    if (this.visibleCount < this.filteredItems.length) {
+      this.intersectionObserver.observe(this.sentinel);
+    }
+  }
+
+  showLoading(active) {
+    if (!this.loadingIndicator) return;
+    this.loadingIndicator.style.display = active ? 'flex' : 'none';
+  }
+
+  storeScrollPosition() {
+    try {
+      sessionStorage.setItem(SCROLL_STORAGE_KEY, String(Math.round(window.scrollY || 0)));
+    } catch {}
+  }
+
+  restoreScrollIfNeeded() {
+    if (this.pendingScroll == null) return;
+    const y = this.pendingScroll;
+    this.pendingScroll = null;
+    setTimeout(() => {
+      window.scrollTo(0, y);
+    }, 80);
+    try {
+      sessionStorage.removeItem(SCROLL_STORAGE_KEY);
+    } catch {}
   }
 }
 
 async function loadDynamicActivityDetail() {
   const container = document.getElementById('activity-article-container');
   if (!container) return;
-  const urlParams = new URLSearchParams(window.location.search);
-  const id = urlParams.get('id');
+
+  const params = new URLSearchParams(window.location.search);
+  const id = params.get('id');
   if (!id) return;
 
+  const breadcrumbTitle = document.getElementById('activity-title-breadcrumb');
   const pageTitle = document.getElementById('page-title');
   const notFound = document.getElementById('article-not-found');
-  const fmtDate = (d) => new Date(d).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' });
 
   try {
-    container.innerHTML = '<p class="text-center">読み込み中...</p>';
+    container.innerHTML = '<p class="text-center text-gray-500">読み込み中...</p>';
     const resp = await fetch(`/api/activities/${encodeURIComponent(id)}`);
     if (!resp.ok) throw new Error('Network response was not ok');
-    const a = await resp.json();
-    if (!a || !a.id) throw new Error('Not found');
-    if (pageTitle) pageTitle.textContent = a.title || '';
-    const tags = Array.isArray(a.tags) ? a.tags : [];
-    const tagBadges = tags.slice(0, 12).map(t => `<span class="badge badge--tag mr-2 mb-2">#${escapeHTML(t)}</span>`).join('');
-    const unitBadge = a.unit ? `<span class="badge badge--unit mr-2">${escapeHTML(a.unit)}</span>` : '';
-    const catBadge  = a.category ? `<span class="badge badge--category">${escapeHTML(a.category)}</span>` : '';
-    const dateLabel = a.activity_date ? fmtDate(a.activity_date) : fmtDate(a.created_at);
-    container.innerHTML = `
-      <article class="bg-white p-6 rounded-xl shadow-lg">
-        <div class="flex items-center justify-between mb-3">
-          <div class="flex items-center gap-2 flex-wrap">${unitBadge}${catBadge}</div>
-          <div class="text-sm text-gray-500">${dateLabel}</div>
-        </div>
-        <h1 class="text-2xl font-bold mb-4">${escapeHTML(a.title || '')}</h1>
-        <div class="mb-4 flex flex-wrap">${tagBadges}</div>
-        <div class="prose max-w-none">${a.content || ''}</div>
-      </article>`;
+    const activity = await resp.json();
+    if (!activity || !activity.id) throw new Error('Not found');
 
-    // 画像ギャラリー（image_urls）を本文の前に追加
-    try {
-      const imgs = Array.isArray(a.image_urls) ? a.image_urls : [];
-      if (imgs.length) {
-        const toEmbed = (u) => {
-          try {
-            const url = new URL(u, location.origin);
-            if (url.hostname.includes('drive.google.com')) {
-              const m = url.pathname.match(/\/file\/d\/([^/]+)\/view/);
-              if (m) return `https://drive.google.com/uc?export=view&id=${m[1]}`;
-              const id = url.searchParams.get('id');
-              if (id) return `https://drive.google.com/uc?export=view&id=${id}`;
-            }
-            return url.href;
-          } catch { return u; }
-        };
-        const galleryHtml = `
-          <div class="space-y-4">
-            <div>
-              <img class="w-full max-h-[60vh] object-cover rounded-xl shadow" src="${toEmbed(imgs[0])}" alt="${escapeHTML(a.title||'')}">
-            </div>
-            ${imgs.length>1 ? `<div class="grid grid-cols-2 sm:grid-cols-3 gap-3">${imgs.slice(1,7).map(src=>`
-              <a href="${toEmbed(src)}" target="_blank" rel="noopener" class="block">
-                <img src="${toEmbed(src)}" alt="${escapeHTML(a.title||'')}" class="w-full h-32 sm:h-36 object-cover rounded-lg border" loading="lazy">
-              </a>
-            `).join('')}</div>` : ''}
-          </div>`;
-        const articleEl = container.querySelector('article');
-        const proseEl = articleEl?.querySelector('.prose');
-        if (proseEl) proseEl.insertAdjacentHTML('beforebegin', galleryHtml);
-        // 戻るリンク
-        proseEl?.insertAdjacentHTML('afterend', '<div class="mt-8"><a href="activity-log.html" class="text-green-700 hover:text-green-900 font-semibold">← 活動一覧へ戻る</a></div>');
-      }
-    } catch {}
-  } catch (err) {
-    console.error('Failed to fetch activity detail:', err);
-    if (notFound) notFound.classList.remove('hidden');
+    const normalized = normalizeActivity(activity);
+    if (breadcrumbTitle) breadcrumbTitle.textContent = normalized.title || '活動報告';
+    if (pageTitle) pageTitle.textContent = `${normalized.title || '活動報告詳細'} - ボーイスカウト多治見第一団`;
+
+    container.innerHTML = buildActivityDetailTemplate(normalized);
+    enhanceActivityArticle(container, normalized);
+  } catch (error) {
+    console.error('Failed to fetch activity detail:', error);
     container.innerHTML = '';
+    if (notFound) notFound.classList.remove('hidden');
   }
 }
 
+function buildActivityDetailTemplate(item) {
+  const accent = resolveAccentTheme(item);
+  const tags = Array.isArray(item._tags) ? item._tags : [];
+  const tagsHtml = tags.map((tag) => `<a href="activity-log.html?tags=${encodeURIComponent(tag)}" class="activity-card__tag" data-tag-link="${escapeHTML(tag)}">#${escapeHTML(tag)}</a>`).join('');
+  const tagSection = tagsHtml ? `<div class="activity-detail-tags">${tagsHtml}</div>` : '';
+  let backLink = 'activity-log.html';
+  try {
+    const lastQuery = sessionStorage.getItem(HISTORY_QUERY_KEY);
+    if (lastQuery) backLink += lastQuery;
+  } catch {}
+  const metaParts = [];
+  if (item._displayDate) metaParts.push(`<span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M8 7V3M16 7V3M4.5 11h15M5 5h14a2 2 0 012 2v12a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2z"></path></svg>${escapeHTML(item._displayDate)}</span>`);
+  if (item.unit) metaParts.push(`<span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4z"></path><path d="M6 20a6 6 0 0112 0"></path></svg>${escapeHTML(item.unit)}</span>`);
+  if (item.category) metaParts.push(`<span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7h18"></path><path d="M5 7v14h14V7"></path><path d="M9 7V5a3 3 0 016 0v2"></path></svg>${escapeHTML(item.category)}</span>`);
+
+  return `
+    <div class="max-w-6xl mx-auto" style="--accent-color:${accent.color}">
+      <div class="flex flex-col gap-4 mb-8">
+        <div class="flex items-center gap-3 flex-wrap">
+          <span class="activity-card__badge" style="--badge-bg:${accent.badgeBg};--badge-color:${accent.badgeColor};">${escapeHTML(accent.typeLabel)}</span>
+          ${item._isImportant ? '<span class="activity-card__status" aria-label="重要なお知らせ">重要</span>' : ''}
+          ${item._isRecent && !item._isImportant ? '<span class="activity-card__status" style="color:#1d4ed8;background:rgba(59,130,246,0.16)">NEW</span>' : ''}
+        </div>
+        <h1 class="text-3xl md:text-4xl font-bold text-gray-900 leading-tight">${escapeHTML(item.title || '')}</h1>
+        <div class="activity-detail-meta">${metaParts.join('')}</div>
+        ${tagSection}
+      </div>
+      <div class="grid gap-10 lg:grid-cols-[minmax(0,3fr)_minmax(220px,1fr)]">
+        <div class="space-y-8" id="activity-article-main">
+          <div id="activity-hero-media"></div>
+          <div class="lg:hidden">
+            <details class="activity-toc-mobile hidden" id="activity-toc-mobile">
+              <summary>目次 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"></path></svg></summary>
+              <nav id="activity-toc-mobile-list" class="activity-toc-list mt-3"></nav>
+            </details>
+          </div>
+          <div class="prose max-w-none prose-lg leading-relaxed">${item.content || ''}</div>
+          <div>
+            <a href="${backLink}" class="return-link">← 条件を保持して一覧へ戻る</a>
+          </div>
+        </div>
+        <aside class="activity-toc-sticky space-y-5 hidden lg:block">
+          <div class="activity-toc-card hidden" id="activity-toc-card">
+            <p class="activity-toc-title">目次</p>
+            <nav id="activity-toc" class="activity-toc-list"></nav>
+          </div>
+          <div class="activity-toc-card" id="activity-meta-card">
+            <p class="activity-toc-title">この記事について</p>
+            <div class="space-y-3 text-sm text-gray-600">
+              ${item._displayDate ? `<p>公開日: <time datetime="${escapeHTML(item._isoDate || '')}">${escapeHTML(item._displayDate)}</time></p>` : ''}
+              ${item.unit ? `<p>所属: ${escapeHTML(item.unit)}</p>` : ''}
+              ${item.category ? `<p>カテゴリ: ${escapeHTML(item.category)}</p>` : ''}
+            </div>
+          </div>
+        </aside>
+      </div>
+    </div>
+  `;
+}
+
+function enhanceActivityArticle(container, item) {
+  const hero = container.querySelector('#activity-hero-media');
+  if (hero) {
+    buildGallery(hero, item);
+  }
+  const prose = container.querySelector('.prose');
+  if (prose) {
+    buildTableOfContents(prose, container);
+  }
+}
+
+function buildGallery(wrapper, item) {
+  const images = Array.isArray(item.image_urls) ? item.image_urls : [];
+  if (!images.length) {
+    wrapper.remove();
+    return;
+  }
+  const normalized = images.map(normalizeImageUrl).filter(Boolean);
+  if (!normalized.length) {
+    wrapper.remove();
+    return;
+  }
+  const main = normalized[0];
+  const others = normalized.slice(1, 6);
+  const mainHtml = `<div class="overflow-hidden rounded-2xl shadow-xl border border-gray-200"><img src="${escapeHTML(main)}" alt="${escapeHTML(item.title || '')}" class="w-full h-auto max-h-[70vh] object-cover"></div>`;
+  const thumbs = others.length ? `<div class="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-4">${others.map((url) => `<a href="${escapeHTML(url)}" target="_blank" rel="noopener" class="block overflow-hidden rounded-xl border border-gray-200 hover:border-green-400 transition"><img src="${escapeHTML(url)}" alt="${escapeHTML(item.title || '')}" class="w-full h-32 sm:h-36 object-cover"></a>`).join('')}</div>` : '';
+  wrapper.innerHTML = `${mainHtml}${thumbs}`;
+}
+
+function buildTableOfContents(prose, root) {
+  const headings = Array.from(prose.querySelectorAll('h2, h3')).filter((heading) => heading.textContent && heading.textContent.trim().length > 0);
+  const tocCard = root.querySelector('#activity-toc-card');
+  const tocList = tocCard?.querySelector('#activity-toc');
+  const mobileWrapper = root.querySelector('#activity-toc-mobile');
+  const mobileList = root.querySelector('#activity-toc-mobile-list');
+  if (!headings.length || !tocList) {
+    tocCard?.classList?.add('hidden');
+    mobileWrapper?.classList?.add('hidden');
+    return;
+  }
+  tocCard.classList.remove('hidden');
+  if (mobileWrapper) mobileWrapper.classList.remove('hidden');
+  tocList.innerHTML = '';
+  if (mobileList) mobileList.innerHTML = '';
+  const fragment = document.createDocumentFragment();
+  const mobileFragment = document.createDocumentFragment();
+  headings.forEach((heading, index) => {
+    if (!heading.id) heading.id = `section-${index + 1}`;
+    const depth = heading.tagName === 'H3' ? 3 : 2;
+    const text = heading.textContent.trim();
+    const link = document.createElement('a');
+    link.className = 'activity-toc-link';
+    link.dataset.target = heading.id;
+    link.dataset.depth = String(depth);
+    link.href = `#${heading.id}`;
+    link.textContent = text;
+    link.addEventListener('click', (event) => {
+      event.preventDefault();
+      document.getElementById(heading.id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      history.replaceState({}, '', `#${heading.id}`);
+    });
+    fragment.appendChild(link);
+    if (mobileList) {
+      const mobileLink = link.cloneNode(true);
+      mobileFragment.appendChild(mobileLink);
+    }
+  });
+  tocList.appendChild(fragment);
+  if (mobileList) mobileList.appendChild(mobileFragment);
+
+  const tocLinks = tocList.querySelectorAll('.activity-toc-link');
+  const mobileLinks = mobileList ? mobileList.querySelectorAll('.activity-toc-link') : [];
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (!entry.isIntersecting) return;
+      const id = entry.target.id;
+      tocLinks.forEach((link) => {
+        link.classList.toggle('is-active', link.dataset.target === id);
+      });
+      mobileLinks.forEach((link) => {
+        link.classList.toggle('is-active', link.dataset.target === id);
+      });
+    });
+  }, { rootMargin: '-55% 0px -35% 0px', threshold: [0, 0.25, 0.5, 1] });
+  headings.forEach((heading) => observer.observe(heading));
+}

--- a/styles/activity-dashboard.css
+++ b/styles/activity-dashboard.css
@@ -1,0 +1,452 @@
+/* Activity dashboard specific enhancements */
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 9999px;
+  padding: 0.45rem 0.95rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1;
+  color: #1f2937;
+  background: rgba(15, 118, 110, 0.08);
+  border: 1px solid rgba(14, 116, 144, 0.12);
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.chip:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px -15px rgba(15, 118, 110, 0.45);
+}
+
+.chip:focus-visible {
+  outline: 2px solid rgba(34, 197, 94, 0.8);
+  outline-offset: 2px;
+}
+
+.chip svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.chip__count {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.chip--ghost {
+  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(34, 197, 94, 0.35);
+  color: #166534;
+}
+
+.chip--outline {
+  background: #ffffff;
+  border-color: #d1d5db;
+  color: #1f2937;
+}
+
+.chip--solid {
+  background: #15803d;
+  border-color: #15803d;
+  color: #ffffff;
+  box-shadow: 0 12px 25px -15px rgba(21, 128, 61, 0.7);
+}
+
+.chip--active {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  border-color: rgba(22, 163, 74, 0.9);
+  color: #ffffff;
+  box-shadow: 0 16px 35px -18px rgba(22, 163, 74, 0.7);
+}
+
+.chip.is-muted {
+  opacity: 0.65;
+}
+
+.custom-scroll {
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(15, 118, 110, 0.5) transparent;
+}
+
+.custom-scroll::-webkit-scrollbar {
+  height: 6px;
+}
+
+.custom-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.custom-scroll::-webkit-scrollbar-thumb {
+  background: rgba(15, 118, 110, 0.35);
+  border-radius: 9999px;
+}
+
+.loading-spinner {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 9999px;
+  border: 3px solid rgba(16, 185, 129, 0.25);
+  border-top-color: rgba(16, 185, 129, 0.95);
+  animation: dashboard-spin 0.8s linear infinite;
+}
+
+@keyframes dashboard-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.activity-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(145deg, #ffffff 0%, #f8fafc 100%);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(15, 118, 110, 0.08);
+  box-shadow: 0 24px 45px -30px rgba(15, 118, 110, 0.4);
+  overflow: hidden;
+  min-height: 100%;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.activity-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(16, 185, 129, 0.2);
+  box-shadow: 0 35px 65px -35px rgba(16, 185, 129, 0.55);
+}
+
+.activity-card__accent {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.4rem;
+  background: var(--accent-color, #16a34a);
+  border-radius: 0 1rem 1rem 0;
+}
+
+.activity-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.9rem;
+  background: var(--icon-bg, rgba(16, 185, 129, 0.12));
+  color: var(--icon-color, #16a34a);
+}
+
+.activity-card__type {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.activity-card__type-label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--type-color, var(--icon-color, #0f172a));
+}
+
+.activity-card__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: #b91c1c;
+  background: rgba(248, 113, 113, 0.18);
+}
+
+.activity-card__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+  line-height: 1.4;
+  margin-bottom: 0.75rem;
+}
+
+.activity-card__title a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.activity-card__title a:hover {
+  color: #15803d;
+}
+
+.activity-card__summary {
+  font-size: 0.97rem;
+  color: #475569;
+  line-height: 1.65;
+  margin-bottom: 1.15rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.line-clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.activity-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: #64748b;
+  margin-bottom: 1rem;
+}
+
+.activity-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.activity-card__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 9999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  background: var(--badge-bg, rgba(148, 163, 184, 0.15));
+  color: var(--badge-color, #1f2937);
+  transition: background-color 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+}
+
+.activity-card__badge:hover {
+  background: rgba(16, 185, 129, 0.15);
+  color: #0f172a;
+}
+
+.activity-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-bottom: 1rem;
+}
+
+.activity-card__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.28rem 0.7rem;
+  border-radius: 9999px;
+  font-size: 0.74rem;
+  font-weight: 600;
+  background: var(--tag-bg, rgba(16, 185, 129, 0.12));
+  color: var(--tag-color, #047857);
+  cursor: pointer;
+  transition: transform 0.15s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.activity-card__tag:hover {
+  transform: translateY(-1px);
+  background: rgba(16, 185, 129, 0.2);
+}
+
+.activity-card__tag.is-active {
+  background: var(--tag-active-bg, rgba(14, 165, 233, 0.18));
+  color: var(--tag-active-color, #0369a1);
+}
+
+.activity-card__link {
+  margin-top: auto;
+  font-weight: 700;
+  color: #15803d;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.activity-card__link:hover {
+  color: #166534;
+  transform: translateX(4px);
+}
+
+.activity-card__link svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+/* Activity detail enhancements */
+
+.activity-toc-card,
+.activity-toc-mobile {
+  background: #f8fafc;
+  border: 1px solid rgba(15, 118, 110, 0.12);
+  border-radius: 1rem;
+  box-shadow: 0 25px 45px -35px rgba(15, 118, 110, 0.35);
+}
+
+.activity-toc-card {
+  padding: 1.25rem 1.5rem;
+}
+
+.activity-toc-mobile {
+  padding: 0.75rem 1rem 1rem;
+}
+
+.activity-toc-title {
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #0f172a;
+  margin-bottom: 0.75rem;
+}
+
+.activity-toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.activity-toc-link {
+  display: block;
+  color: #475569;
+  font-size: 0.9rem;
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  padding-left: 0.75rem;
+  border-radius: 0.5rem;
+  transition: color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.activity-toc-link:hover {
+  color: #047857;
+  border-color: rgba(34, 197, 94, 0.5);
+  background: rgba(16, 185, 129, 0.08);
+}
+
+.activity-toc-link.is-active {
+  color: #0f172a;
+  font-weight: 600;
+  border-color: rgba(16, 185, 129, 0.9);
+  background: rgba(16, 185, 129, 0.15);
+}
+
+.activity-toc-link[data-depth="3"] {
+  font-size: 0.84rem;
+  padding-left: 1.4rem;
+  opacity: 0.85;
+}
+
+.activity-toc-mobile summary {
+  font-weight: 700;
+  color: #0f172a;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  list-style: none;
+}
+
+.activity-toc-mobile summary::-webkit-details-marker {
+  display: none;
+}
+
+.activity-toc-mobile summary svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.activity-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.activity-detail-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.activity-detail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.activity-detail-tags a {
+  text-decoration: none;
+}
+
+.activity-detail-tags .activity-card__tag {
+  margin-bottom: 0;
+}
+
+@media (min-width: 1024px) {
+  .activity-toc-sticky {
+    position: sticky;
+    top: 6.5rem;
+  }
+}
+
+.prose h2,
+.prose h3,
+.prose h4 {
+  scroll-margin-top: 6.5rem;
+}
+
+.return-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 700;
+  color: #047857;
+  text-decoration: none;
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.return-link svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.return-link:hover {
+  color: #065f46;
+  transform: translateX(-3px);
+}
+
+@media (max-width: 767px) {
+  .chip {
+    padding: 0.4rem 0.8rem;
+  }
+
+  .activity-card {
+    border-radius: 1.25rem;
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the activity log filters with a chip-based control panel, quick tag bar, and refreshed results section that highlights guidance and load-more states
- implement an ActivityDashboard controller that keeps filters in the URL, supports AND/OR tag logic, infinite scroll, scroll restoration, and enriches the detail view with a gallery and generated table of contents
- add shared dashboard styles for chips, activity cards, and article navigation and load them on both the list and detail pages

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c91a25d2a083249da7c8b7206c84e8