### PR TITLE
Implement contact form email sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@
 - `PORT`（任意）未設定時は 10000
 - `HOST`（任意）未設定時は `0.0.0.0`
 - `HMAC_TOLERANCE_SEC`（任意）デフォルト 300 秒
+- `SMTP_HOST`（必須）お問い合わせフォームで使用するSMTPサーバーホスト名
+- `SMTP_PORT`（任意）デフォルトは 587
+- `SMTP_SECURE`（任意）`true` の場合は SMTPS (既定ポート 465) を利用
+- `SMTP_STARTTLS`（任意）`false` で STARTTLS を無効化（デフォルトは `SMTP_SECURE=false` のとき自動的に STARTTLS を試行）
+- `SMTP_REQUIRE_TLS`（任意）`true` で STARTTLS の利用を必須化
+- `SMTP_TLS_REJECT_UNAUTHORIZED`（任意）`false` で自己署名証明書を許容
+- `SMTP_USER` / `SMTP_PASS`（任意）SMTP 認証が必要な場合の資格情報
+- `SMTP_FROM`（必須）送信メールの From ヘッダ（例: `"多治見第一団" <noreply@example.jp>`）
+- `CONTACT_FORM_FROM`（任意）From ヘッダを個別指定したい場合に設定（未設定時は `SMTP_FROM` を使用）
+- `DEFAULT_CONTACT_EMAIL`（任意）管理画面でメールアドレス未設定時の送信先フォールバック
 
 3) DB 初期化
 - `npm run db:setup`

--- a/common-scripts.js
+++ b/common-scripts.js
@@ -387,41 +387,146 @@ function initContactForm() {
   const form = document.getElementById('contact-form');
   if (!form) return;
 
+  form.setAttribute('novalidate', 'novalidate');
+
+  const successBox = document.getElementById('form-success-message');
+  const errorBox = document.getElementById('form-error-message');
+  const successDetail = successBox ? successBox.querySelector('[data-success-detail]') : null;
+  const errorDetail = errorBox ? errorBox.querySelector('[data-error-detail]') : null;
+  const defaultSuccessMessage = successDetail ? successDetail.textContent : '';
+  const defaultErrorMessage = errorDetail ? errorDetail.textContent : '';
+
+  const fieldErrors = {
+    name: document.getElementById('name-error'),
+    email: document.getElementById('email-error'),
+    message: document.getElementById('message-error'),
+  };
+
+  const hideAllFieldErrors = () => {
+    Object.values(fieldErrors).forEach((el) => {
+      if (el) el.classList.add('hidden');
+    });
+  };
+
+  const setFieldError = (field, message) => {
+    const el = fieldErrors[field];
+    if (!el) return;
+    if (message) {
+      el.textContent = message;
+      el.classList.remove('hidden');
+    } else {
+      el.classList.add('hidden');
+    }
+  };
+
+  const hideFeedback = () => {
+    if (successBox) {
+      successBox.classList.add('hidden');
+      if (successDetail) successDetail.textContent = defaultSuccessMessage;
+    }
+    if (errorBox) {
+      errorBox.classList.add('hidden');
+      if (errorDetail) errorDetail.textContent = defaultErrorMessage;
+    }
+  };
+
+  const showSuccess = (message) => {
+    if (!successBox) return;
+    if (successDetail) successDetail.textContent = message || defaultSuccessMessage;
+    successBox.classList.remove('hidden');
+    successBox.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
+  const showError = (message) => {
+    if (!errorBox) return;
+    if (errorDetail) errorDetail.textContent = message || defaultErrorMessage;
+    errorBox.classList.remove('hidden');
+    errorBox.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
+  form.addEventListener('input', (event) => {
+    const target = event.target;
+    if (target && target.name && fieldErrors[target.name]) {
+      fieldErrors[target.name].classList.add('hidden');
+    }
+  });
+
   form.addEventListener('submit', async function (e) {
     e.preventDefault();
 
+    hideFeedback();
+    hideAllFieldErrors();
+
     const submitButton = form.querySelector('button[type="submit"]');
-    const originalButtonText = submitButton.innerHTML;
-    submitButton.disabled = true;
-    submitButton.innerHTML = '<span class="animate-spin h-5 w-5 mr-3 border-t-2 border-b-2 border-white rounded-full inline-block"></span> 送信中...';
+    const originalButtonText = submitButton ? submitButton.innerHTML : '';
+    if (submitButton) {
+      submitButton.disabled = true;
+      submitButton.innerHTML = '<span class="animate-spin h-5 w-5 mr-3 border-t-2 border-b-2 border-white rounded-full inline-block"></span> 送信中...';
+    }
 
     const formData = new FormData(form);
-    const data = Object.fromEntries(formData.entries());
+    const payload = {
+      name: (formData.get('name') || '').toString().trim(),
+      email: (formData.get('email') || '').toString().trim(),
+      phone: (formData.get('phone') || '').toString().trim(),
+      subject: (formData.get('subject') || '').toString().trim(),
+      message: (formData.get('message') || '').toString().trim(),
+    };
+
+    const validationErrors = {};
+    if (!payload.name) {
+      validationErrors.name = 'お名前を入力してください。';
+    }
+    if (!payload.email) {
+      validationErrors.email = 'メールアドレスを入力してください。';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(payload.email)) {
+      validationErrors.email = '有効なメールアドレスを入力してください。';
+    }
+    if (!payload.message) {
+      validationErrors.message = 'お問い合わせ内容を入力してください。';
+    }
+
+    if (Object.keys(validationErrors).length > 0) {
+      Object.entries(validationErrors).forEach(([field, message]) => setFieldError(field, message));
+      showError('入力内容を確認してください。');
+      if (submitButton) {
+        submitButton.disabled = false;
+        submitButton.innerHTML = originalButtonText;
+      }
+      return;
+    }
 
     try {
-      // ここで実際のAPIエンドポイントにデータを送信します
       const response = await fetch('/api/contact', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
       });
 
-      const result = await response.json();
+      let result = {};
+      try {
+        result = await response.json();
+      } catch (jsonError) {
+        console.warn('Failed to parse contact form response JSON:', jsonError);
+      }
 
       if (response.ok) {
-        alert(result.message || 'お問い合わせありがとうございます。メッセージが正常に送信されました。');
+        showSuccess(result.message || defaultSuccessMessage);
         form.reset();
       } else {
-        throw new Error(result.message || 'サーバーでエラーが発生しました。');
+        if (result && result.details) {
+          Object.entries(result.details).forEach(([field, message]) => setFieldError(field, message));
+        }
+        showError(result && result.message ? result.message : defaultErrorMessage || '送信に失敗しました。時間をおいて再度お試しください。');
       }
     } catch (error) {
       console.error('フォーム送信エラー:', error);
-      alert('メッセージの送信に失敗しました。時間をおいて再度お試しください。');
+      showError('送信に失敗しました。時間をおいて再度お試しください。');
     } finally {
-      submitButton.disabled = false;
-      submitButton.innerHTML = originalButtonText;
+      if (submitButton) {
+        submitButton.disabled = false;
+        submitButton.innerHTML = originalButtonText;
+      }
     }
   });
 }

--- a/contact.html
+++ b/contact.html
@@ -105,7 +105,7 @@
 
                     <div class="bg-gray-50 p-8 md:p-10 rounded-xl shadow-xl card-hover-effect">
                         <h2 class="text-3xl font-bold text-green-700 mb-8">お問い合わせフォーム</h2>
-                        <form id="contact-form" action="#" method="POST" class="space-y-6">
+                        <form id="contact-form" action="#" method="POST" class="space-y-6" novalidate>
                             <div>
                                 <label for="name" class="block text-sm font-medium text-gray-700 mb-1">お名前 <span class="text-red-500">*</span></label>
                                 <input type="text" name="name" id="name" autocomplete="name" required
@@ -145,13 +145,13 @@
                                 </button>
                             </div>
                         </form>
-                        <div id="form-success-message" class="hidden mt-6 p-4 bg-green-100 border-l-4 border-green-500 text-green-700 rounded-md">
+                        <div id="form-success-message" class="hidden mt-6 p-4 bg-green-100 border-l-4 border-green-500 text-green-700 rounded-md" role="status" aria-live="polite">
                             <p class="font-semibold">お問い合わせありがとうございます！</p>
-                            <p>メッセージが正常に送信されました。担当者より折り返しご連絡いたしますので、今しばらくお待ちください。</p>
+                            <p data-success-detail>メッセージが正常に送信されました。担当者より折り返しご連絡いたしますので、今しばらくお待ちください。</p>
                         </div>
-                        <div id="form-error-message" class="hidden mt-6 p-4 bg-red-100 border-l-4 border-red-500 text-red-700 rounded-md">
+                        <div id="form-error-message" class="hidden mt-6 p-4 bg-red-100 border-l-4 border-red-500 text-red-700 rounded-md" role="alert" aria-live="assertive">
                             <p class="font-semibold">送信に失敗しました</p>
-                            <p>恐れ入りますが、時間をおいて再度お試しいただくか、お電話にてお問い合わせください。</p>
+                            <p data-error-detail>恐れ入りますが、時間をおいて再度お試しいただくか、お電話にてお問い合わせください。</p>
                         </div>
                     </div>
                 </div>

--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ const bcrypt = require('bcrypt');
 
 const db = require('./database.js');
 const { logSecretFingerprint } = require('./utils/logSecretFingerprint');
+const { sendMail } = require('./utils/mailer');
 
 const app = express();
 app.set('trust proxy', 1);
@@ -701,6 +702,129 @@ app.get('/api/public-settings', async (req, res) => {
   } catch (err) {
     console.error('GET /api/public-settings error:', err);
     return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+app.post('/api/contact', async (req, res) => {
+  const { name, email, phone, subject, message } = req.body || {};
+
+  const trim = (value) => (typeof value === 'string' ? value.trim() : '');
+  const trimmedName = trim(name);
+  const trimmedEmail = trim(email);
+  const trimmedPhone = trim(phone);
+  const trimmedSubject = trim(subject);
+  const trimmedMessage = typeof message === 'string' ? message.trim() : '';
+
+  const errors = {};
+  if (!trimmedName) {
+    errors.name = 'お名前を入力してください。';
+  }
+
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!trimmedEmail) {
+    errors.email = 'メールアドレスを入力してください。';
+  } else if (!emailPattern.test(trimmedEmail)) {
+    errors.email = '有効なメールアドレスを入力してください。';
+  }
+
+  if (!trimmedMessage) {
+    errors.message = 'お問い合わせ内容を入力してください。';
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return res.status(400).json({
+      error: 'validation_error',
+      message: '入力内容を確認してください。',
+      details: errors,
+    });
+  }
+
+  try {
+    const { rows } = await db.query(
+      'SELECT value FROM settings WHERE key = $1 LIMIT 1',
+      ['contact_email']
+    );
+
+    const rawRecipients = rows[0]?.value || '';
+    const sanitizeRecipient = (value) => value.replace(/[\r\n]+/g, ' ').trim();
+    let recipients = rawRecipients
+      .split(/[,;\n]+/)
+      .map((item) => sanitizeRecipient(item))
+      .filter(Boolean);
+
+    if (recipients.length === 0 && process.env.DEFAULT_CONTACT_EMAIL) {
+      recipients = process.env.DEFAULT_CONTACT_EMAIL
+        .split(/[,;\n]+/)
+        .map((item) => sanitizeRecipient(item))
+        .filter(Boolean);
+    }
+
+    if (recipients.length === 0) {
+      console.error('contact_email is not configured');
+      return res.status(500).json({
+        error: 'contact_email_not_configured',
+        message: '送信先が設定されていないためお問い合わせを送信できませんでした。恐れ入りますが、時間をおいて再度お試しください。',
+      });
+    }
+
+    const fromAddress = (process.env.CONTACT_FORM_FROM || process.env.SMTP_FROM || '').trim();
+    if (!fromAddress) {
+      console.error('SMTP_FROM/CONTACT_FORM_FROM is not configured');
+      return res.status(500).json({
+        error: 'mailer_not_configured',
+        message: '送信に失敗しました。時間をおいて再度お試しください。',
+      });
+    }
+
+    const sanitizeSingleLine = (value) => value.replace(/[\r\n]+/g, ' ').trim();
+    const safeName = sanitizeSingleLine(trimmedName).slice(0, 120);
+    const safeEmail = sanitizeSingleLine(trimmedEmail);
+    const safePhone = sanitizeSingleLine(trimmedPhone);
+    const safeSubject = sanitizeSingleLine(trimmedSubject).slice(0, 120) || 'お問い合わせ';
+    const safeMessage = (typeof message === 'string'
+      ? message.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim()
+      : '').slice(0, 5000);
+
+    const subjectLineParts = [`[お問い合わせ] ${safeSubject}`];
+    if (safeName) subjectLineParts.push(`- ${safeName}`);
+    const subjectLine = subjectLineParts.join(' ');
+
+    const nowIso = new Date().toISOString();
+    const textLines = [
+      'ボーイスカウト多治見第一団のサイトから新しいお問い合わせを受信しました。',
+      '',
+      `お名前: ${safeName || '（未入力）'}`,
+      `メールアドレス: ${safeEmail || '（未入力）'}`,
+    ];
+
+    if (safePhone) {
+      textLines.push(`電話番号: ${safePhone}`);
+    }
+
+    textLines.push(`件名: ${safeSubject}`);
+    textLines.push(`送信日時: ${nowIso}`);
+    textLines.push('');
+    textLines.push('----- お問い合わせ内容 -----');
+    textLines.push(safeMessage || '（本文なし）');
+    textLines.push('------------------------------');
+
+    await sendMail({
+      from: fromAddress,
+      to: recipients,
+      replyTo: safeEmail || undefined,
+      subject: subjectLine,
+      text: textLines.join('\n'),
+    });
+
+    return res.status(200).json({
+      message: 'お問い合わせありがとうございます。担当者より折り返しご連絡いたします。',
+    });
+  } catch (err) {
+    console.error('POST /api/contact error:', err);
+    return res.status(500).json({
+      error: 'failed_to_send',
+      message: '送信に失敗しました。時間をおいて再度お試しください。',
+    });
   }
 });
 

--- a/utils/mailer.js
+++ b/utils/mailer.js
@@ -1,0 +1,417 @@
+const net = require('node:net');
+const tls = require('node:tls');
+const os = require('node:os');
+const { randomBytes } = require('node:crypto');
+
+const DEFAULT_SMTP_TIMEOUT = 15000;
+
+function parseBoolean(value, defaultValue = false) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value !== 'string') return defaultValue;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+  return defaultValue;
+}
+
+function sanitizeHeaderValue(value) {
+  return String(value || '').replace(/[\r\n]+/g, ' ').trim();
+}
+
+function encodeHeader(header, value) {
+  const sanitized = sanitizeHeaderValue(value);
+  if (!/[\u0080-\uFFFF]/.test(sanitized)) {
+    return `${header}: ${sanitized}`;
+  }
+  const base64 = Buffer.from(sanitized, 'utf8').toString('base64');
+  return `${header}: =?UTF-8?B?${base64}?=`;
+}
+
+function extractEmailAddress(address) {
+  if (!address) return '';
+  const match = /<([^>]+)>/.exec(address);
+  const value = match ? match[1] : address;
+  return sanitizeHeaderValue(value);
+}
+
+function buildMessageId(domain) {
+  const host = sanitizeHeaderValue(domain || os.hostname() || 'localhost');
+  const id = `${Date.now().toString(36)}.${randomBytes(8).toString('hex')}`;
+  return `<${id}@${host}>`;
+}
+
+function buildMessage({ from, to, subject, text, replyTo }) {
+  const recipients = Array.isArray(to) ? to : [to];
+  const headerLines = [
+    `From: ${sanitizeHeaderValue(from)}`,
+    `To: ${recipients.map(sanitizeHeaderValue).join(', ')}`,
+    encodeHeader('Subject', subject || ''),
+    `Date: ${new Date().toUTCString()}`,
+    `Message-ID: ${buildMessageId()}`,
+    'MIME-Version: 1.0',
+    'Content-Type: text/plain; charset=UTF-8',
+    'Content-Transfer-Encoding: 8bit',
+  ];
+
+  if (replyTo) {
+    headerLines.splice(2, 0, `Reply-To: ${sanitizeHeaderValue(replyTo)}`);
+  }
+
+  const rawText = String(text || '');
+  const bodyLines = rawText
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .split('\n')
+    .map((line) => (line.startsWith('.') ? `.${line}` : line));
+
+  return `${headerLines.join('\r\n')}\r\n\r\n${bodyLines.join('\r\n')}`;
+}
+
+class SMTPClient {
+  constructor(options) {
+    this.options = options;
+    this.socket = null;
+    this.currentHost = options.host;
+    this.timeout = options.timeout || DEFAULT_SMTP_TIMEOUT;
+    this.secure = Boolean(options.secure);
+    this.rejectUnauthorized = parseBoolean(options.rejectUnauthorized, true);
+  }
+
+  async connect() {
+    if (this.socket) return;
+    const { host, port = 587 } = this.options;
+
+    await new Promise((resolve, reject) => {
+      const onError = (err) => {
+        cleanup();
+        reject(err);
+      };
+
+      const onConnect = () => {
+        cleanup();
+        this.socket.setTimeout(this.timeout);
+        resolve();
+      };
+
+      const cleanup = () => {
+        if (!this.socket) return;
+        this.socket.off('error', onError);
+        this.socket.off('timeout', onTimeout);
+      };
+
+      const onTimeout = () => {
+        cleanup();
+        reject(new Error('SMTP connection timed out'));
+      };
+
+      if (this.secure) {
+        this.socket = tls.connect(
+          {
+            host,
+            port,
+            servername: host,
+            rejectUnauthorized: this.rejectUnauthorized,
+            timeout: this.timeout,
+          },
+          onConnect,
+        );
+      } else {
+        this.socket = net.createConnection({ host, port }, onConnect);
+      }
+
+      this.socket.once('error', onError);
+      this.socket.once('timeout', onTimeout);
+    });
+  }
+
+  async upgradeToTLS() {
+    if (!this.socket) throw new Error('Socket is not initialized');
+
+    this.socket = await new Promise((resolve, reject) => {
+      const secureSocket = tls.connect(
+        {
+          socket: this.socket,
+          servername: this.currentHost,
+          rejectUnauthorized: this.rejectUnauthorized,
+          timeout: this.timeout,
+        },
+        () => {
+          secureSocket.setTimeout(this.timeout);
+          resolve(secureSocket);
+        },
+      );
+      secureSocket.once('error', (err) => {
+        secureSocket.destroy();
+        reject(err);
+      });
+    });
+
+    this.secure = true;
+  }
+
+  async write(command) {
+    if (!this.socket) throw new Error('Socket is not initialized');
+    await new Promise((resolve, reject) => {
+      this.socket.write(command, 'utf8', (err) => {
+        if (err) return reject(err);
+        return resolve();
+      });
+    });
+  }
+
+  async readResponse() {
+    if (!this.socket) throw new Error('Socket is not initialized');
+
+    return new Promise((resolve, reject) => {
+      let buffer = '';
+
+      const onData = (chunk) => {
+        buffer += chunk.toString('utf8');
+        if (!buffer.includes('\n')) return;
+
+        const lines = buffer.split(/\r?\n/);
+        let idx = lines.length - 1;
+        while (idx >= 0 && lines[idx] === '') idx--;
+        if (idx < 0) return;
+
+        const line = lines[idx];
+        const match = line.match(/^(\d{3})([ -])(.*)$/);
+        if (!match) return;
+        if (match[2] === '-') {
+          return;
+        }
+
+        cleanup();
+        const responseLines = lines.slice(0, idx + 1).filter((l) => l);
+        resolve({
+          code: Number(match[1]),
+          lines: responseLines,
+        });
+      };
+
+      const onError = (err) => {
+        cleanup();
+        reject(err);
+      };
+
+      const onClose = () => {
+        cleanup();
+        reject(new Error('SMTP connection closed unexpectedly'));
+      };
+
+      const onTimeout = () => {
+        cleanup();
+        reject(new Error('SMTP response timeout'));
+      };
+
+      const cleanup = () => {
+        if (!this.socket) return;
+        this.socket.off('data', onData);
+        this.socket.off('error', onError);
+        this.socket.off('close', onClose);
+        this.socket.off('timeout', onTimeout);
+      };
+
+      this.socket.on('data', onData);
+      this.socket.once('error', onError);
+      this.socket.once('close', onClose);
+      this.socket.once('timeout', onTimeout);
+    });
+  }
+
+  async sendCommand(command, acceptedCodes) {
+    await this.write(`${command}\r\n`);
+    const response = await this.readResponse();
+    if (acceptedCodes && !acceptedCodes.includes(response.code)) {
+      const preview = response.lines.join('\n');
+      throw new Error(`Unexpected SMTP response to "${command}": ${response.code} ${preview}`);
+    }
+    return response;
+  }
+
+  async sendData(data) {
+    const normalized = data.replace(/\r?\n/g, '\r\n');
+    const withEnding = normalized.endsWith('\r\n') ? normalized : `${normalized}\r\n`;
+    await this.write(`${withEnding}.\r\n`);
+    return this.readResponse();
+  }
+
+  async quit() {
+    try {
+      await this.sendCommand('QUIT', [221]);
+    } catch (err) {
+      // Ignore quit errors
+    }
+    if (this.socket) {
+      this.socket.end();
+      this.socket = null;
+    }
+  }
+}
+
+function parseEhloCapabilities(lines) {
+  const caps = { auth: [], features: [] };
+  lines.forEach((line) => {
+    const cleaned = line.replace(/^250[ -]/, '');
+    caps.features.push(cleaned.toUpperCase());
+    const authMatch = cleaned.match(/^AUTH\s+(.*)$/i);
+    if (authMatch) {
+      caps.auth = authMatch[1]
+        .split(/\s+/)
+        .map((method) => method.trim().toUpperCase())
+        .filter(Boolean);
+    }
+  });
+  return caps;
+}
+
+async function authenticate(client, auth, capabilities) {
+  if (!auth || !auth.user) return;
+  const methods = capabilities.auth || [];
+  const password = auth.pass || '';
+
+  if (methods.includes('PLAIN')) {
+    const token = Buffer.from(`\u0000${auth.user}\u0000${password}`, 'utf8').toString('base64');
+    const response = await client.sendCommand(`AUTH PLAIN ${token}`, [235, 503]);
+    if (response.code === 235 || response.code === 503) return;
+  }
+
+  if (methods.includes('LOGIN')) {
+    const first = await client.sendCommand('AUTH LOGIN', [334, 503]);
+    if (first.code === 503) return;
+    if (first.code !== 334) {
+      throw new Error('SMTP AUTH LOGIN rejected');
+    }
+    const userResponse = await client.sendCommand(Buffer.from(auth.user, 'utf8').toString('base64'), [334]);
+    if (userResponse.code !== 334) {
+      throw new Error('SMTP AUTH LOGIN username rejected');
+    }
+    await client.sendCommand(Buffer.from(password, 'utf8').toString('base64'), [235]);
+    return;
+  }
+
+  if (methods.length > 0) {
+    throw new Error('SMTP server does not support AUTH PLAIN or AUTH LOGIN');
+  }
+
+  // Some servers do not advertise AUTH. Attempt PLAIN as a best-effort fallback.
+  const token = Buffer.from(`\u0000${auth.user}\u0000${password}`, 'utf8').toString('base64');
+  await client.sendCommand(`AUTH PLAIN ${token}`, [235, 503]);
+}
+
+function getMailerConfigFromEnv() {
+  const host = process.env.SMTP_HOST && process.env.SMTP_HOST.trim();
+  if (!host) {
+    throw new Error('SMTP_HOST is not configured');
+  }
+
+  const port = Number(process.env.SMTP_PORT || (parseBoolean(process.env.SMTP_SECURE, false) ? 465 : 587));
+  const secure = parseBoolean(process.env.SMTP_SECURE, port === 465);
+  const startTLS = parseBoolean(process.env.SMTP_STARTTLS, !secure);
+  const requireTLS = parseBoolean(process.env.SMTP_REQUIRE_TLS, false);
+  const rejectUnauthorized = parseBoolean(process.env.SMTP_TLS_REJECT_UNAUTHORIZED, true);
+  const timeout = Number(process.env.SMTP_TIMEOUT_MS || DEFAULT_SMTP_TIMEOUT);
+  const clientHostname = process.env.SMTP_CLIENT_HOSTNAME || os.hostname() || 'localhost';
+
+  const user = process.env.SMTP_USER;
+  const pass = process.env.SMTP_PASS;
+  const auth = user ? { user, pass: pass || '' } : null;
+
+  return {
+    host,
+    port,
+    secure,
+    startTLS,
+    requireTLS,
+    rejectUnauthorized,
+    timeout,
+    auth,
+    clientHostname,
+  };
+}
+
+async function sendMail(messageOptions, overrideConfig) {
+  const baseConfig = overrideConfig || getMailerConfigFromEnv();
+  const toList = Array.isArray(messageOptions.to) ? messageOptions.to : [messageOptions.to];
+  if (!messageOptions.from) {
+    throw new Error('Missing "from" address');
+  }
+  if (!toList.length || !toList[0]) {
+    throw new Error('Missing "to" address');
+  }
+
+  const envelopeFrom = sanitizeHeaderValue(
+    messageOptions.envelopeFrom || extractEmailAddress(messageOptions.from),
+  );
+  const envelopeRecipients = toList.map((addr) => sanitizeHeaderValue(extractEmailAddress(addr)));
+
+  const client = new SMTPClient(baseConfig);
+
+  const message = buildMessage({
+    from: messageOptions.from,
+    to: toList,
+    subject: messageOptions.subject || '',
+    text: messageOptions.text || '',
+    replyTo: messageOptions.replyTo,
+  });
+
+  try {
+    await client.connect();
+    const greeting = await client.readResponse();
+    if (greeting.code !== 220) {
+      throw new Error(`SMTP greeting failed: ${greeting.lines.join(' ')}`);
+    }
+
+    let ehloResponse;
+    try {
+      ehloResponse = await client.sendCommand(`EHLO ${sanitizeHeaderValue(baseConfig.clientHostname)}`, [250]);
+    } catch (err) {
+      ehloResponse = await client.sendCommand(`HELO ${sanitizeHeaderValue(baseConfig.clientHostname)}`, [250]);
+    }
+
+    let capabilities = parseEhloCapabilities(ehloResponse.lines);
+
+    if (!client.secure && baseConfig.startTLS) {
+      const supportsStartTLS = capabilities.features.some((feature) => feature.includes('STARTTLS'));
+      if (!supportsStartTLS) {
+        if (baseConfig.requireTLS) {
+          throw new Error('SMTP server does not support STARTTLS');
+        }
+      } else {
+        await client.sendCommand('STARTTLS', [220]);
+        await client.upgradeToTLS();
+        const ehloAfterTls = await client.sendCommand(`EHLO ${sanitizeHeaderValue(baseConfig.clientHostname)}`, [250]);
+        capabilities = parseEhloCapabilities(ehloAfterTls.lines);
+      }
+    }
+
+    if (baseConfig.auth) {
+      await authenticate(client, baseConfig.auth, capabilities);
+    }
+
+    await client.sendCommand(`MAIL FROM:<${envelopeFrom}>`, [250, 251]);
+    for (const recipient of envelopeRecipients) {
+      await client.sendCommand(`RCPT TO:<${recipient}>`, [250, 251, 252]);
+    }
+    await client.sendCommand('DATA', [354]);
+    const dataResponse = await client.sendData(message);
+    if (dataResponse.code !== 250) {
+      throw new Error(`SMTP message rejected: ${dataResponse.lines.join(' ')}`);
+    }
+    await client.quit();
+  } catch (error) {
+    try {
+      await client.quit();
+    } catch {
+      // ignore
+    }
+    throw error;
+  }
+}
+
+module.exports = {
+  sendMail,
+  getMailerConfigFromEnv,
+  parseBoolean,
+};


### PR DESCRIPTION
## Summary
- add an SMTP mailer utility that can connect with TLS/STARTTLS and send plain-text messages
- expose `/api/contact` to validate form submissions, look up the admin email setting, and deliver the message via SMTP
- enhance the public contact form to show inline validation, surface success/error banners, and document the new SMTP environment variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c91bd987b4832498c842f557c65f5d