### PR TITLE
Improve global styling and load Tailwind utilities

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/activity-detail-placeholder.html
+++ b/activity-detail-placeholder.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <link rel="stylesheet" href="styles/lightbox.css">
     <script defer src="common-scripts.js"></script>

--- a/activity-log.html
+++ b/activity-log.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/common-scripts.js
+++ b/common-scripts.js
@@ -9,6 +9,7 @@ const COMMON_SETTINGS = {
   mobileMenuStoreName: 'mobileMenu',
   smoothScrollSelector: 'a[href^="#"]:not([href="#"])',
   scrollToTopSelector: 'a[href="#"]',
+  backToTopId: 'back-to-top-button',
 };
 
 /**
@@ -63,6 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initTiltEffect();
   initSimpleLightboxPlaceholder();
   initLazyLoadImages(); // 画像の遅延読み込みを初期化
+  initBackToTopButton();
 
   // --- 特定のページでのみ実行する初期化処理 ---
   if (document.getElementById('hero')) {
@@ -651,6 +653,40 @@ function initSmoothScroll() {
       window.scrollTo({ top: 0, behavior: 'smooth' });
     });
   });
+}
+
+function initBackToTopButton() {
+  if (!document.body) return;
+  if (document.getElementById(COMMON_SETTINGS.backToTopId)) return;
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.id = COMMON_SETTINGS.backToTopId;
+  button.className = 'back-to-top';
+  button.setAttribute('aria-label', 'ページ上部へ戻る');
+  button.innerHTML = [
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">',
+    '<path d="M12 19V5" />',
+    '<path d="M5 12l7-7 7 7" />',
+    '</svg>',
+    '<span class="sr-only">ページトップに戻る</span>'
+  ].join('');
+
+  document.body.appendChild(button);
+
+  const toggleVisibility = () => {
+    const shouldShow = window.scrollY > 480;
+    button.classList.toggle('is-visible', shouldShow);
+  };
+
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+
+  window.addEventListener('scroll', toggleVisibility, { passive: true });
+  window.addEventListener('resize', toggleVisibility, { passive: true });
+  toggleVisibility();
 }
 
 /**

--- a/common-styles.css
+++ b/common-styles.css
@@ -7,8 +7,10 @@
     --primary-color: #15803d; /* Tailwind green-700 (少し明るめに変更) */
     --primary-color-darker: #166534; /* Tailwind green-800 */
     --primary-color-hover: #16a34a; /* Tailwind green-600 */
+    --primary-color-rgb: 21, 128, 61; /* 主色のRGB。透過演出などで利用 */
     --secondary-color: #f59e0b; /* amber-500: 視認性改善 */
     --secondary-color-hover: #d97706; /* amber-600 */
+    --secondary-color-rgb: 245, 158, 11;
 
     --text-color-base: #1f2937; /* Tailwind gray-800 */
     --text-color-muted: #4b5563; /* Tailwind gray-600 */
@@ -51,11 +53,52 @@
 body {
     font-family: var(--font-family-sans);
     color: var(--text-color-base);
-    background-color: var(--bg-color-base);
+    background-color: var(--bg-color-soft);
+    background-image:
+        radial-gradient(1200px circle at 10% -10%, rgba(var(--primary-color-rgb), 0.12), transparent 55%),
+        radial-gradient(800px circle at 85% 20%, rgba(var(--secondary-color-rgb), 0.14), transparent 60%),
+        linear-gradient(180deg, #ffffff 0%, #f8fafc 60%, #f1f5f9 100%);
+    background-attachment: fixed;
     font-size: 16px;
     line-height: 1.75;
+    min-height: 100vh;
+    position: relative;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+}
+
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+        linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+        linear-gradient(180deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+    background-size: 40px 40px;
+    opacity: 0.35;
+    z-index: -1;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+main {
+    position: relative;
+    z-index: 1;
+}
+
+section[id] {
+    scroll-margin-top: clamp(5.5rem, 7vw, 6.5rem);
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -104,6 +147,19 @@ img {
 /* スムーズスクロール */
 html {
     scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
 }
 
 /* ============================================== */
@@ -187,6 +243,63 @@ header#main-header.scrolled {
 }
 /* モバイルメニュー自体のスタイルはTailwindで制御されていると想定 */
 /* #mobile-menu-alpine a { ... } などで微調整可能 */
+
+
+/* ============================================== */
+/* FOOTER                                         */
+/* ============================================== */
+footer.bg-gray-800 {
+    position: relative;
+    background: radial-gradient(circle at 10% 10%, rgba(148, 163, 184, 0.18), transparent 55%),
+                radial-gradient(circle at 90% 0%, rgba(22, 101, 52, 0.25), transparent 50%),
+                linear-gradient(180deg, #1f2937 0%, #0f172a 100%);
+    color: rgba(226, 232, 240, 0.92);
+    overflow: hidden;
+}
+
+footer.bg-gray-800::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.05), transparent 70%);
+    pointer-events: none;
+    z-index: 0;
+}
+
+footer.bg-gray-800 .container {
+    position: relative;
+    z-index: 1;
+}
+
+footer.bg-gray-800 .text-gray-400 {
+    color: rgba(226, 232, 240, 0.82) !important;
+}
+
+footer.bg-gray-800 .text-gray-500 {
+    color: rgba(203, 213, 225, 0.75) !important;
+}
+
+footer.bg-gray-800 a {
+    color: inherit;
+    text-decoration: none;
+}
+
+footer.bg-gray-800 a:hover {
+    color: var(--secondary-color);
+    text-decoration: none;
+}
+
+footer.bg-gray-800 hr {
+    border-color: rgba(148, 163, 184, 0.25);
+}
+
+footer.bg-gray-800 .icon {
+    color: rgba(226, 232, 240, 0.85);
+}
+
+footer.bg-gray-800 .icon:hover {
+    color: #fff;
+}
 
 
 /* ============================================== */
@@ -571,6 +684,74 @@ header#main-header.scrolled {
 .skeleton-thumb { width: 100%; height: 11rem; border-radius: var(--border-radius-lg); }
 .skeleton-text { height: 0.875rem; border-radius: 9999px; margin: 0.375rem 0; }
 @keyframes skeleton-loading { 0% { background-position: 100% 0 } 100% { background-position: 0 0 } }
+
+/* ページトップに戻るボタン */
+.back-to-top {
+    position: fixed;
+    bottom: clamp(1.5rem, 2.5vw, 2.75rem);
+    right: clamp(1.25rem, 2vw, 2.5rem);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3.25rem;
+    height: 3.25rem;
+    border-radius: var(--border-radius-full);
+    background: linear-gradient(135deg, rgba(var(--primary-color-rgb), 0.95), rgba(var(--primary-color-rgb), 0.78));
+    color: var(--text-color-inverted);
+    box-shadow: 0 20px 35px -15px rgba(var(--primary-color-rgb), 0.65), 0 10px 18px -12px rgba(15, 23, 42, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    backdrop-filter: blur(6px);
+    cursor: pointer;
+    transition: transform 0.35s cubic-bezier(0.33, 1, 0.68, 1), opacity 0.35s ease, box-shadow 0.35s ease;
+    opacity: 0;
+    transform: translateY(20px);
+    pointer-events: none;
+    z-index: 70;
+}
+
+.back-to-top svg {
+    width: 1.35rem;
+    height: 1.35rem;
+}
+
+.back-to-top:hover {
+    transform: translateY(0) scale(1.05);
+    box-shadow: 0 24px 40px -20px rgba(var(--primary-color-rgb), 0.75);
+}
+
+.back-to-top:focus-visible {
+    outline: 3px solid rgba(var(--primary-color-rgb), 0.45);
+    outline-offset: 4px;
+}
+
+.back-to-top.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+@media (max-width: 640px) {
+    .back-to-top {
+        width: 2.75rem;
+        height: 2.75rem;
+        bottom: 1.25rem;
+        right: 1rem;
+        box-shadow: 0 14px 25px -15px rgba(var(--primary-color-rgb), 0.8);
+    }
+
+    .back-to-top svg {
+        width: 1.15rem;
+        height: 1.15rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .back-to-top,
+    .back-to-top:hover {
+        transition: none !important;
+        transform: none !important;
+    }
+}
 
 /* カードのホバー強化（微妙な拡大と影強化） */
 .card-hover-effect { transition: transform .2s ease, box-shadow .2s ease; }

--- a/contact.html
+++ b/contact.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
 
     <script defer src="common-scripts.js"></script>

--- a/join.html
+++ b/join.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/news-detail-placeholder.html
+++ b/news-detail-placeholder.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <link rel="stylesheet" href="styles/lightbox.css">
     <script defer src="common-scripts.js"></script>

--- a/news-list.html
+++ b/news-list.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="enhance-news.js"></script>

--- a/privacy.html
+++ b/privacy.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/sitemap.html
+++ b/sitemap.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/testimonials.html
+++ b/testimonials.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/unit-beaver.html
+++ b/unit-beaver.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/unit-boy.html
+++ b/unit-boy.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/unit-cub.html
+++ b/unit-cub.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/unit-rover.html
+++ b/unit-rover.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>

--- a/unit-venture.html
+++ b/unit-venture.html
@@ -7,6 +7,28 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                colors: {
+                    primary: '#15803d',
+                    "primary-dark": '#166534',
+                    secondary: '#f59e0b'
+                },
+                fontFamily: {
+                    sans: ['Noto Sans JP', 'sans-serif'],
+                    heading: ['M PLUS Rounded 1c', 'sans-serif']
+                }
+            }
+        },
+        corePlugins: {
+            preflight: false
+        }
+    };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <link rel="stylesheet" href="common-styles.css">
     <script defer src="common-scripts.js"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>


### PR DESCRIPTION
## Summary
- load the Tailwind CDN with a shared config on every static page so existing utility classes render consistently
- refresh the base theme in `common-styles.css` with a layered background, anchor offsets, footer polish, and styles for a new floating “back to top” control
- add a script-driven floating back-to-top button that toggles with scroll state for easier navigation

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68c91c0b9e0c8324995521dd318af024